### PR TITLE
Lists package managers in the Download Center

### DIFF
--- a/src/config/graknRoutes.js
+++ b/src/config/graknRoutes.js
@@ -1,7 +1,10 @@
 const docBase = 'https://dev.grakn.ai';
 
 module.exports = {
-  setup: `${docBase}/docs/running-grakn/install-and-run#using-homebrew`,
+  homebrew: `${docBase}/docs/running-grakn/install-and-run?tab=mac-os-x#using-homebrew`,
+  rpm: `${docBase}/docs/running-grakn/install-and-run?tab=linux#using-rpm-yum`,
+  debian: `${docBase}/docs/running-grakn/install-and-run?tab=linux#using-debian`,
+  docker: `${docBase}/docs/running-grakn/install-and-run?tab=docker`,
   docs: docBase,
   overview: `${docBase}/overview/`,
   quickstart: `${docBase}/docs/general/quickstart`,

--- a/src/pages/DownloadCentrePage.js
+++ b/src/pages/DownloadCentrePage.js
@@ -235,7 +235,13 @@ class DownloadCentrePage extends Component {
                       </div>
                       <a className="button button--transparent downloads__splash__main__tabpanel__content__core__col__content__github" href={graknRoutes.github} target="_blank">STAR ON GITHUB <i className="fa fa-2x fa-github" aria-hidden={true} /> </a>
                       <div className="downloads__splash__main__tabpanel__content__core__col__content__packagemanager">
-                        <a className="animated__link animated__link--purple" href={graknRoutes.setup}>Download and install with Homebrew</a>
+                      Download and install with:
+                      <ul>
+                        <li><a className="animated__link animated__link--purple" href={graknRoutes.homebrew}>Homebrew</a></li>
+                        <li><a className="animated__link animated__link--purple" href={graknRoutes.rpm}>RPM</a></li>
+                        <li><a className="animated__link animated__link--purple" href={graknRoutes.debian}>APT</a></li>
+                        <li><a className="animated__link animated__link--purple" href={graknRoutes.homebrew}>Docker</a></li>
+                      </ul>
                       </div>
                       <Form className="downloads__splash__main__tabpanel__content__core__col__content__selectgroup">
                       <Select value={this.state.platformCore} name='platform' onChange={(e) => this.switchPlatform(e.target.value)}>

--- a/src/stylesheets/pages/_downloads.scss
+++ b/src/stylesheets/pages/_downloads.scss
@@ -202,7 +202,7 @@
                   border: solid 1px #c3c8d2;
                   font-weight: 300;
                   color: $textCharcoal;
-                  margin-left: 35px;
+                  margin-left: 30px;
                   margin-top: 0 !important;
                   > i {
                     display: inline-block;
@@ -267,31 +267,30 @@
                   }
                 }
                 &__packagemanager {
-                  padding: 50px 0 55px 0;
+                  padding: 26px 0;
+                  ul {
+                    padding: 0 25px;
+                    margin: 5px 0;
+                  }
                   > span {
-                    font-size: 18px;
+                    font-size: 14px;
                     color: $textCharcoal;
                     font-weight: 400;
                     display: block;
                     margin-bottom: 8px;
-                    @media screen and (max-width: $smallScreen) {
-                      font-size: 16px;
-                    }
-                  }
-                  > a {
-                    font-size: 16px;
-                    display: block;
-                    line-height: 1.67;
-                    @media screen and (max-width: $smallScreen) {
-                      font-size: 14px;
-                    }
 
+                    > a {
+                      font-size: 14px;
+                      font-weight: 600;
+                      line-height: 1.67;
+                    }
                   }
                 }
                 &__checkbox {
                   padding-bottom: 1rem;
                   > i {
                     margin-right: 10px;
+                    margin-top: 5px;
                     padding: 4px;
                     border-radius: 50%;
                     font-weight: 300;


### PR DESCRIPTION
Add links for installing Grakn with package managers. Links point to one of the tabs and headers located in http://dev.grakn.ai/docs/running-grakn/install-and-run 