### PR TITLE
Version 2.14 update

### DIFF
--- a/server/api/TypeDBController.java
+++ b/server/api/TypeDBController.java
@@ -8,6 +8,6 @@ import static com.vaticle.web.main.server.api.APIUtils.okResult;
 
 public class TypeDBController extends Controller {
     public Result version() {
-        return okResult(new JsonObject().add("version", "2.14.0").toString());
+        return okResult(new JsonObject().add("version", "2.14.1").toString());
     }
 }

--- a/web/pages/download/typedb-studio-tab.tsx
+++ b/web/pages/download/typedb-studio-tab.tsx
@@ -40,12 +40,12 @@ const defaultOSMap: {[key in OS]: keyof Downloads} = {
     Other: "macOS",
 }
 
-const latestReleaseDateFormatted = moment(new Date("2022-11-24")).format("Do [of] MMMM YYYY");
-const studioVersion = "2.14.0";
+const latestReleaseDateFormatted = moment(new Date("2022-11-25")).format("Do [of] MMMM YYYY");
+const studioVersion = "2.14.1";
 const latestReleaseNotesURL = `${urls.github.typedbStudioReleases}/tag/${studioVersion}`;
 const downloads: Downloads = {
     "Ubuntu / Debian": {
-        "2.14.0": "https://github.com/vaticle/typedb-studio/releases/download/2.14.0/typedb-studio_2.14.0-1_amd64.deb",
+        "2.14.1": "https://github.com/vaticle/typedb-studio/releases/download/2.14.1/typedb-studio_2.14.1-1_amd64.deb",
         "2.11.0": "https://github.com/vaticle/typedb-studio/releases/download/2.11.0/typedb-studio_2.11.0-1_amd64.deb",
         "2.1.2": "https://github.com/vaticle/typedb-workbase/releases/download/2.1.2/typedb-workbase-linux-2.1.2.AppImage",
         "2.1.0": "https://github.com/vaticle/typedb-workbase/releases/download/2.1.0/typedb-workbase-linux-2.1.0.AppImage",
@@ -54,11 +54,11 @@ const downloads: Downloads = {
         "2.0.0": "https://github.com/vaticle/typedb-workbase/releases/download/2.0.0/grakn-workbase-linux-2.0.0.AppImage",
     },
     "Linux (cross-platform)": {
-        "2.14.0": "https://github.com/vaticle/typedb-studio/releases/download/2.14.0/typedb-studio-linux-2.14.0.tar.gz",
+        "2.14.1": "https://github.com/vaticle/typedb-studio/releases/download/2.14.1/typedb-studio-linux-2.14.1.tar.gz",
         "2.11.0": "https://github.com/vaticle/typedb-studio/releases/download/2.11.0/typedb-studio-linux-2.11.0.tar.gz",
     },
     "macOS": {
-        "2.14.0": "https://github.com/vaticle/typedb-studio/releases/download/2.14.0/typedb-studio-mac-2.14.0.dmg",
+        "2.14.1": "https://github.com/vaticle/typedb-studio/releases/download/2.14.1/typedb-studio-mac-2.14.1.dmg",
         "2.11.0": "https://github.com/vaticle/typedb-studio/releases/download/2.11.0/typedb-studio-mac-2.11.0.dmg",
         "2.1.2": "https://github.com/vaticle/typedb-workbase/releases/download/2.1.2/typedb-workbase-mac-2.1.2.dmg",
         "2.1.0": "https://github.com/vaticle/typedb-workbase/releases/download/2.1.0/typedb-workbase-mac-2.1.0.dmg",
@@ -67,7 +67,7 @@ const downloads: Downloads = {
         "2.0.0": "https://github.com/vaticle/typedb-workbase/releases/download/2.0.0/grakn-workbase-mac-2.0.0.dmg",
     },
     "Windows": {
-        "2.14.0": "https://github.com/vaticle/typedb-studio/releases/download/2.14.0/typedb-studio-windows-2.14.0.exe",
+        "2.14.1": "https://github.com/vaticle/typedb-studio/releases/download/2.14.1/typedb-studio-windows-2.14.1.exe",
         "2.11.0": "https://github.com/vaticle/typedb-studio/releases/download/2.11.0/typedb-studio-windows-2.11.0.exe",
         "2.1.2": "https://github.com/vaticle/typedb-workbase/releases/download/2.1.2/typedb-workbase-win-2.1.2.exe",
         "2.1.0": "https://github.com/vaticle/typedb-workbase/releases/download/2.1.0/typedb-workbase-win-2.1.0.exe",
@@ -77,7 +77,7 @@ const downloads: Downloads = {
     },
 };
 const defaultOS: keyof Downloads = defaultOSMap[getCurrentOS()];
-const defaultVersion: string = "2.14.0";
+const defaultVersion: string = "2.14.1";
 
 const OpenSourcePane: React.FC = () => {
     const classes = Object.assign({}, vaticleStyles(), downloadPageProductStyles(), comparisonStyles());
@@ -125,7 +125,7 @@ const OpenSourcePane: React.FC = () => {
                 </VaticleSelect>
                 <VaticleSelect label="Version" value={selectedVersion} setValue={setSelectedVersion} inputName="version"
                                inputID="typedb-version" variant="outlined">
-                    <option value="2.14.0">2.14.0</option>
+                    <option value="2.14.1">2.14.1</option>
                     {selectedOS !== "Linux (cross-platform)" &&
                     <>
                         <option value="2.11.0">2.11.0</option>

--- a/web/pages/download/typedb-tab.tsx
+++ b/web/pages/download/typedb-tab.tsx
@@ -22,7 +22,7 @@ const items: [ComparisonBlockItem, ComparisonBlockItem] = [{
 
 export const TypeDBTab: React.FC = () => <ComparisonBlock items={items}/>;
 
-type TypeDBVersion = "2.14.0" | "2.13.0" | "2.12.0" | "2.11.1" | "2.11.0" | "2.10.0" | "2.8.1" | "2.8.0" | "2.7.1"
+type TypeDBVersion = "2.14.1" | "2.13.0" | "2.12.0" | "2.11.1" | "2.11.0" | "2.10.0" | "2.8.1" | "2.8.0" | "2.7.1"
     | "2.7.0" | "2.6.4" | "2.6.3" | "2.6.2" | "2.6.1" | "2.6.0" | "2.5.0" | "2.4.0" | "2.3.3" | "2.3.2" | "2.3.1"
     | "2.3.0" | "2.2.0" | "2.1.3" | "2.1.1" | "2.0.2" | "2.0.1" | "2.0.0";
 
@@ -43,10 +43,10 @@ const defaultOSMap: {[key in OS]: keyof Downloads} = {
     Other: "macOS",
 }
 
-const latestReleaseDateFormatted = moment(new Date("2022-11-24")).format("Do [of] MMMM YYYY");
+const latestReleaseDateFormatted = moment(new Date("2022-11-25")).format("Do [of] MMMM YYYY");
 const downloads: Downloads = {
     "macOS": {
-        "2.14.0": "https://github.com/vaticle/typedb/releases/download/2.14.0/typedb-all-mac-2.14.0.zip",
+        "2.14.1": "https://github.com/vaticle/typedb/releases/download/2.14.1/typedb-all-mac-2.14.1.zip",
         "2.13.0": "https://github.com/vaticle/typedb/releases/download/2.13.0/typedb-all-mac-2.13.0.zip",
         "2.12.0": "https://github.com/vaticle/typedb/releases/download/2.12.0/typedb-all-mac-2.12.0.zip",
         "2.11.1": "https://github.com/vaticle/typedb/releases/download/2.11.1/typedb-all-mac-2.11.1.zip",
@@ -75,7 +75,7 @@ const downloads: Downloads = {
         "2.0.0": "https://github.com/vaticle/typedb/releases/download/2.0.0/grakn-core-all-mac-2.0.0.zip",
     },
     "Linux": {
-        "2.14.0": "https://github.com/vaticle/typedb/releases/download/2.14.0/typedb-all-linux-2.14.0.tar.gz",
+        "2.14.1": "https://github.com/vaticle/typedb/releases/download/2.14.1/typedb-all-linux-2.14.1.tar.gz",
         "2.13.0": "https://github.com/vaticle/typedb/releases/download/2.13.0/typedb-all-linux-2.13.0.tar.gz",
         "2.11.1": "https://github.com/vaticle/typedb/releases/download/2.11.1/typedb-all-linux-2.11.1.tar.gz",
         "2.11.0": "https://github.com/vaticle/typedb/releases/download/2.11.0/typedb-all-linux-2.11.0.tar.gz",
@@ -103,7 +103,7 @@ const downloads: Downloads = {
         "2.0.0": "https://github.com/vaticle/typedb/releases/download/2.0.0/grakn-core-all-linux-2.0.0.tar.gz",
     },
     "Windows": {
-        "2.14.0": "https://github.com/vaticle/typedb/releases/download/2.14.0/typedb-all-windows-2.14.0.zip",
+        "2.14.1": "https://github.com/vaticle/typedb/releases/download/2.14.1/typedb-all-windows-2.14.1.zip",
         "2.13.0": "https://github.com/vaticle/typedb/releases/download/2.13.0/typedb-all-windows-2.13.0.zip",
         "2.11.1": "https://github.com/vaticle/typedb/releases/download/2.11.1/typedb-all-windows-2.11.1.zip",
         "2.11.0": "https://github.com/vaticle/typedb/releases/download/2.11.0/typedb-all-windows-2.11.0.zip",


### PR DESCRIPTION
## What is the goal of this PR?

We've updated our main site to reflect the release of TypeDB 2.14.0.

## What are the changes implemented in this PR?

We've updated the API, dates of release and versions for TypeDB and TypeDB Studio.