### PR TITLE
Update Cluster page

### DIFF
--- a/web/pages/typedbcluster/typedb-cluster-examples.ts
+++ b/web/pages/typedbcluster/typedb-cluster-examples.ts
@@ -3,9 +3,11 @@ export const highAvailabilityExample = `> database replicas my-typedb
 my-typedb
 
 > database replicas my-typedb
-{ address: typedb-cluster-2:1729; role: primary; term: 87 }
+{ address: typedb-cluster-0:1729; role: primary; term: 87 }
 { address: typedb-cluster-1:1729; role: secondary; term: 87 }
-{ address: typedb-cluster-0:1729; role: secondary; term: 87 }
+{ address: typedb-cluster-2:1729; role: secondary; term: 87 }
+{ address: typedb-cluster-3:1729; role: secondary; term: 87 }
+{ address: typedb-cluster-4:1729; role: secondary; term: 87 }
 `;
 
 export const elasticThroughputExample = `

--- a/web/pages/typedbcluster/typedb-cluster-page.tsx
+++ b/web/pages/typedbcluster/typedb-cluster-page.tsx
@@ -46,6 +46,7 @@ export const TypeDBClusterPage: React.FC = () => {
                               load-balancing transparently for applications."
                                          button={{text: "Documentation", href: urls.docs.home}}>
                     <ConsoleCodeExample code={elasticThroughputExample}/>
+                </KeyPointWithCodeExample>
                 <KeyPointWithCodeExample id="authentication" className={classes.subsectionMargin} examplePosition="left"
                                          title="User Authentication"
                                          body="TypeDB Cluster ensures users are authorised to perform user/database


### PR DESCRIPTION
## What is the goal of this PR?

We've updated the TypeDB Cluster page to reflect the most recent information about Cluster.

## What are the changes implemented in this PR?

We've updated the TypeDB Cluster page to reflect:
- the output of its correct `database replicas` command
- that role-based user management is coming soon.
- that TypeDB Cloud is coming soon! But you won't be able to find Cluster on any of the common cloud platform marketplaces.