### PR TITLE
Fix visual bug with line-clamp in Safari across the main site

### DIFF
--- a/website/src/framework/link-panels/link-panels.component.scss
+++ b/website/src/framework/link-panels/link-panels.component.scss
@@ -115,6 +115,7 @@
                 line-clamp: 7;
                 -webkit-box-orient: vertical;
                 overflow: hidden;
+                max-height: 24px * 7;
             }
         }
 
@@ -129,6 +130,7 @@
                 margin-top: 8px;
                 -webkit-line-clamp: 3;
                 line-clamp: 3;
+                max-height: 18px * 3;
             }
         }
     }

--- a/website/src/page/webinars-page/webinars-page.component.scss
+++ b/website/src/page/webinars-page/webinars-page.component.scss
@@ -3,10 +3,7 @@
 @import "../background";
 
 article {
-    @include page-background(
-        "features_02june 1.png",
-        "planet-yellow-green.png"
-    );
+    @include page-background("features_02june 1.png", "planet-yellow-green.png");
 }
 
 .wp-primary-placeholder {
@@ -68,10 +65,12 @@ article {
     line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
+    max-height: 24px * 2;
 
     @media (max-width: $media-max-width-mobile) {
         -webkit-line-clamp: 3;
         line-clamp: 3;
+        max-height: 21px * 3;
     }
 }
 

--- a/website/src/page/white-papers-page/white-papers-page.component.scss
+++ b/website/src/page/white-papers-page/white-papers-page.component.scss
@@ -126,8 +126,14 @@ article {
 .wp-grid-item-description {
     margin-top: 8px;
     @include line-clamp(2);
+    max-height: 28px * 2;
+
+    @media (max-width: $media-max-width-tablet) {
+        max-height: 24px * 2;
+    }
 
     @media (max-width: $media-max-width-mobile) {
         @include line-clamp(3);
+        max-height: 21px * 3;
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

Blocks inside of line-clamp are visible on Safari.
Now line-clamp has max-height specified which makes overflowing blocks hidden.

## What are the changes implemented in this PR?

- max-height is added for elements with line-clamp
- max-height calculated by multiplying line-height and line number

It is not perfect as we don't have access to line-height and it is specified second time for max-height.

