### PR TITLE
Corrects white papers illustrations size ratios

### DIFF
--- a/website/src/page/white-papers-page/white-papers-page.component.scss
+++ b/website/src/page/white-papers-page/white-papers-page.component.scss
@@ -97,30 +97,36 @@ article {
 
     @media (max-width: $media-max-width-mobile) {
         flex-direction: row;
+        align-items: flex-start;
         gap: 12px;
     }
 }
 
 .wp-img-secondary-container {
-    height: 279px;
+    padding-bottom: calc(100% * 9 / 16);
     border: 1px solid $color-vaticle-light-purple;
     border-radius: $border-radius;
     background: $color-vaticle-deep-purple;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    position: relative;
+    overflow: hidden;
+
+    @media (max-width: $media-max-width-tablet) {
+        padding-bottom: calc(100% * 2 / 3);
+    }
 
     @media (max-width: $media-max-width-mobile) {
-        height: auto;
         width: 100px;
+        padding-bottom: 100px;
         flex-shrink: 0;
     }
 }
 
 .wp-img-secondary {
-    display: block;
-    max-width: 100%;
-    max-height: 100%;
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }
 
 .wp-grid-item-description {


### PR DESCRIPTION
## What is the goal of this PR?

White papers illustration on page aggregating white papers were displayed inside container with background and fixed height. They were not overflowing that container and they were keeping original image ratio.
Now illustration cover whole container keeping original image ratio. Overflowing part of image is hidden.

## What are the changes implemented in this PR?

- specified padding-bottom in image container to display different size ratios for absolute positioned images
