### PR TITLE
Fix snackbar icon shrink

### DIFF
--- a/website/src/styles/styles.scss
+++ b/website/src/styles/styles.scss
@@ -621,6 +621,7 @@ input[type="submit"].hs-button {
     width: 20px;
     height: 20px;
     background-image: url("/assets/icon/check-circle.svg");
+    flex-shrink: 0;
 }
 
 .mat-simple-snackbar-action {


### PR DESCRIPTION
## What is the goal of this PR?

Snackbar icon used to shrink which made it partialy hidden;
Now it doesn't shrink and is fully visible;

## What are the changes implemented in this PR?
- added style to disable shrink for snackbar icon
