### PR TITLE
Fix cookie popup on mobile

### DIFF
--- a/website/src/styles/styles.scss
+++ b/website/src/styles/styles.scss
@@ -578,7 +578,7 @@ input[type="submit"].hs-button {
     }
 }
 
-.cc-banner {
+.cc-window {
     background: $color-vaticle-purple;
     border-top: 1px solid $color-vaticle-light-purple;
     font-family: inherit;


### PR DESCRIPTION
## What is the goal of this PR?

Styles for cookie popup on mobile weren't working.
Now styles are always working.

## What are the changes implemented in this PR?

Replaced class `.cc-banner` with `.cc-window`. (`.cc-banner` was not always active)
