### PR TITLE
Implement italics and underline in Rich Text component

### DIFF
--- a/schema/index.ts
+++ b/schema/index.ts
@@ -53,7 +53,7 @@ export { referenceMaterialSchemaName } from "./reference-material";
 export { Document, SanityDataset } from "./sanity-core";
 export { type SanityCommunityResources, communityResourcesSchemaName, type SocialMediaID, SocialMediaLink, socialMedias } from "./social-media";
 export { type SanityTestimonial, Testimonial } from "./testimonial";
-export { ParagraphWithHighlights, RichText, type SanityPortableText, TitleAndBody, TitleBodyIllustrationSection } from "./text";
+export { ParagraphWithHighlights, RichText, type RichTextSpan, type SanityPortableText, TitleAndBody, TitleBodyIllustrationSection } from "./text";
 export { groupBy, associateBy } from "./util";
 export { Webinar, type SanityWebinar, webinarSchemaName } from "./webinar";
 export { WhitePaper, type SanityWhitePaper, whitePaperSchemaName } from "./white-paper";

--- a/schema/text.ts
+++ b/schema/text.ts
@@ -41,8 +41,14 @@ function isPortableTextSpan(block: SanityPortableText[0]["children"][0]): block 
     return block._type === "span";
 }
 
+export interface RichTextSpan {
+    text: string;
+    marks: string[];
+    level?: number;
+}
+
 export class RichText {
-    readonly paragraphs: { spans: { text: string, marks: string[], level?: number }[] }[];
+    readonly paragraphs: { spans: RichTextSpan[] }[];
 
     constructor(data: SanityPortableText) {
         this.paragraphs = data.map(p => ({

--- a/website/src/framework/text/rich-text.component.html
+++ b/website/src/framework/text/rich-text.component.html
@@ -1,6 +1,8 @@
 <p *ngFor="let paragraph of value.paragraphs">
     <ng-container *ngFor="let span of paragraph.spans">
-        <span *ngIf="!span.level" [ngStyle]="span.marks.includes('strong') ? { 'font-weight': '700' } : undefined">{{ span.text }}</span>
-        <ul *ngIf="span.level"><li>{{ span.text }}</li></ul>
+        <span *ngIf="!span.level" [ngClass]="getSpanClasses(span)">{{ span.text }}</span>
+        <ul *ngIf="span.level">
+            <li>{{ span.text }}</li>
+        </ul>
     </ng-container>
 </p>

--- a/website/src/framework/text/rich-text.component.scss
+++ b/website/src/framework/text/rich-text.component.scss
@@ -11,3 +11,15 @@ p + p {
 ul {
     margin-left: 1em;
 }
+
+.rt-em {
+    font-style: italic;
+}
+
+.rt-strong {
+    font-weight: $font-weight-bold;
+}
+
+.rt-underline {
+    text-decoration: underline;
+}

--- a/website/src/framework/text/rich-text.component.ts
+++ b/website/src/framework/text/rich-text.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from "@angular/core";
-import { RichText } from "typedb-web-schema";
+import { RichText, RichTextSpan } from "typedb-web-schema";
 
 @Component({
     selector: "td-rich-text",
@@ -8,4 +8,16 @@ import { RichText } from "typedb-web-schema";
 })
 export class RichTextComponent {
     @Input() value!: RichText;
+
+    private readonly markClasses = {
+        em: "rt-em",
+        strong: "rt-strong",
+        underline: "rt-underline",
+    };
+
+    getSpanClasses(span: RichTextSpan) {
+        return span.marks
+            .filter((mark): mark is keyof typeof this.markClasses => mark in this.markClasses)
+            .map((mark) => this.markClasses[mark]);
+    }
 }


### PR DESCRIPTION
## What is the goal of this PR?

Italic and underline defined in Sanity are now implemented in paragraphs on the website.

## What are the changes implemented in this PR?

- added RichTextSpan interface in schema,
- `ngStyle` in rich-text component was removed in favour of `ngClass`,
- added and styled 3 classes generated from sanity span marks.
