### PR TITLE
Style invalid hubspot form

### DIFF
--- a/website/src/styles/styles.scss
+++ b/website/src/styles/styles.scss
@@ -536,6 +536,17 @@ body .hs-form fieldset.form-columns-1 .hs-input {
     }
 }
 
+.hs-form {
+    .hs-error-msgs,
+    .hs_error_rollup {
+        display: none;
+    }
+
+    .hs-input.error {
+        border-color: $color-vaticle-red;
+    }
+}
+
 #hubspot-form-holder-contact .hs-submit {
     @media (max-width: $media-max-width-mobile) {
         margin-top: 240px;


### PR DESCRIPTION
## What is the goal of this PR?

Submitting HubSpot form used to add error message below input making layout shift.
Now error messages are hidden and errors are indicated by changing border color. Errors do not cause layout shift.

## What are the changes implemented in this PR?

- added style to hide error messages,
- added style to change border color on field error.
