### PR TITLE
Correct Privacy Policy typos

### DIFF
--- a/website/src/page/privacy-policy-page/privacy-policy-page.component.html
+++ b/website/src/page/privacy-policy-page/privacy-policy-page.component.html
@@ -16,8 +16,8 @@
 
             <p>
                 Vaticle Ltd (“We”) take a proactive approach to user privacy and ensure the necessary steps are taken to
-                protect the privacy of its users throughout their visiting experience. This website complies to all UK
-                national laws and requirements for user privacy
+                protect the privacy of its users throughout their visiting experience. This website complies with all UK
+                national laws and requirements for user privacy.
             </p>
         </section>
 
@@ -252,7 +252,7 @@
         </section>
 
         <section>
-            <h2>We may update this Policy</h2>
+            <h2>We may Update this Policy</h2>
 
             <p>
                 From time to time we may change our privacy policies. We will notify you of any material changes to our
@@ -260,7 +260,7 @@
                 periodically for updates.
             </p>
 
-            <p>Vaticle Ltd., 3rd floor, East, 47-50 Margaret St, London W1W 8SE, UK</p>
+            <p>Vaticle Ltd, 3rd Floor, 47-50 Margaret St, London W1W 8SE, UK</p>
         </section>
     </div>
 </article>


### PR DESCRIPTION
## What is the goal of this PR?

Privacy Policy page used to have few typos.
Those typos are now corrected.

## What are the changes implemented in this PR?

Updated text on Privacy Policy page:
- changed "complies to" to "comples with"
- added missing full-stop at end of paragraph
- capitalised "update",
- updated address.