### PR TITLE
Make Netlify Lighthouse plugin target desktop instead of mobile

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -118,3 +118,9 @@ path = "/api/webinars/primary"
 [[edge_functions]]
 function = "webinars-register"
 path = "/api/webinars/register"
+
+[[plugins]]
+  package = "@netlify/plugin-lighthouse"
+
+  [plugins.inputs.settings]
+    preset = "desktop"


### PR DESCRIPTION
## What is the goal of this PR?

Netlify Lighthouse plugin was targeting mobile with its default setting.
It's changed to target desktop now.

## What are the changes implemented in this PR?

Added Netlify Lighthouse config in `netlify.toml`.
