### PR TITLE
Lighthouse Production configuration

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -88,9 +88,9 @@ path = "/api/webinars/register"
   package = "@netlify/plugin-lighthouse"
 
   [context.production.plugins.inputs]
-    # this fixes issue of deploy permalink header impacting SEO score (https://github.com/netlify/netlify-plugin-lighthouse/issues/593)
-    # this option runs plugin on a locally served version instead of deploy permalink
-    # despite the name, it doesn't actually cause deploys to fail, unless the 'threshold' option is also set
+    # This option runs the plugin on a locally served version instead of a deploy permalink,
+    # fixing an issue where a Netlify header would impact SEO score (https://github.com/netlify/netlify-plugin-lighthouse/issues/593).
+    # Despite the name, it doesn't actually fail deploys, unless the 'threshold' option is also set.
     fail_deploy_on_score_thresholds = "true"
 
     [context.production.plugins.inputs.settings]


### PR DESCRIPTION
## What is the goal of this PR?

Netlify Lighthouse plugin was running for every branch using deploy permalink.
Now it hosts build output to be run by Lighthouse.

## What are the changes implemented in this PR?

- changed netlify config to run lighthouse plugin only for production after build stage.