### PR TITLE
Fix contact dialog scroll

### DIFF
--- a/website/src/framework/form/contact-dialog.component.scss
+++ b/website/src/framework/form/contact-dialog.component.scss
@@ -1,10 +1,21 @@
 @import "../../styles/sizes";
 
+:host {
+    position: relative;
+}
+
+.mat-dialog-content {
+    max-height: none;
+    min-height: 506px;
+}
+
 p {
-    align-self: flex-start;
-    margin-top: -36px;
+    position: absolute;
+    bottom: 0;
+    left: 0;
 
     @media (max-width: $media-max-width-mobile) {
+        position: static;
         margin-top: 12px;
     }
 }

--- a/website/src/service/dialog.service.ts
+++ b/website/src/service/dialog.service.ts
@@ -71,6 +71,11 @@ export class DialogService {
     }
 
     openContactDialog() {
-        this.open(ContactDialogComponent, { width: "1088px", height: "568px", maxWidth: "100vw", autoFocus: "input" });
+        this.open(ContactDialogComponent, {
+            width: "1088px",
+            maxWidth: "100vw",
+            maxHeight: "100vh",
+            autoFocus: "input",
+        });
     }
 }

--- a/website/src/styles/styles.scss
+++ b/website/src/styles/styles.scss
@@ -533,6 +533,7 @@ body .hs-form fieldset.form-columns-1 .hs-input {
 
         @media (max-width: $media-max-width-mobile) {
             margin-top: 200px;
+            height: 124px;
         }
     }
 }
@@ -550,7 +551,7 @@ body .hs-form fieldset.form-columns-1 .hs-input {
 
 #hubspot-form-holder-contact .hs-submit {
     @media (max-width: $media-max-width-mobile) {
-        margin-top: 240px;
+        margin-top: 100px;
     }
 }
 


### PR DESCRIPTION
## What is the goal of this PR?

Contact dialog had unnecessary scroll.
Now contact dialog fills full window height if needed.

## What are the changes implemented in this PR?

- removed fixed contact dialog height,
- added more flexible styles to contact-dialog with min height,
- reduced contact-dialog textarea height.
