### PR TITLE
Update privacy policy to refer to the TypeDB website rather than Vaticle

### DIFF
--- a/website/src/page/privacy-policy-page/privacy-policy-page.component.html
+++ b/website/src/page/privacy-policy-page/privacy-policy-page.component.html
@@ -4,8 +4,8 @@
       <h1>Privacy Policy</h1>
 
       <p>
-        This privacy policy is for this website (Vaticle) and governs the privacy of its users who choose to use it. The
-        policy sets out the different areas where user privacy is concerned and outlines the obligations and
+        This privacy policy is for our website located at typedb.com and governs the privacy of its users who choose to
+        use it. The policy sets out the different areas where user privacy is concerned and outlines the obligations and
         requirements of the users, the website and website owners. Furthermore, the way this website processes, stores
         and protects user data and information will also be detailed within this policy.
       </p>
@@ -15,9 +15,10 @@
       <h2>The Website</h2>
 
       <p>
-        Vaticle Ltd (“We”) take a proactive approach to user privacy and ensure the necessary steps are taken to protect
-        the privacy of its users throughout their visiting experience. This website complies with all UK national laws
-        and requirements for user privacy.
+        Vaticle Ltd (collectively referred to as “Vaticle”, “we”, “us”, or “our” in this Privacy Policy) take a
+        proactive approach to user privacy and ensure the necessary steps are taken to protect the privacy of its users
+        throughout their visiting experience. This website complies with all UK national laws and requirements for user
+        privacy.
       </p>
     </section>
 
@@ -54,7 +55,7 @@
         <a href="https://www.hotjar.com/privacy" target="_blank">here</a>.
       </p>
 
-      <p>The cookies used by Vaticle website are described in the list below.</p>
+      <p>The cookies used on our website are described in the list below.</p>
     </section>
 
     <section>
@@ -114,8 +115,7 @@
         Data Protection Act 1998. No personal details are passed on to third parties nor shared with companies/people
         outside of the company that operates this website. Under the Data Protection Act 1998 you may request a copy of
         personal information held about you by this website's email newsletter program. A small fee will be payable. If
-        you would like a copy of the information held on you, please write to the business address contained in the
-        About Us page of Vaticle.
+        you would like a copy of the information held on you, please <a tdLink="?dialog=contact">contact us</a>.
       </p>
 
       <p>
@@ -184,7 +184,7 @@
       <h2>Shortened Links in Social Media</h2>
 
       <p>
-        Vaticle Ltd through their social media platform accounts may share web links to relevant web pages. By default,
+        Vaticle may, through their social media platform accounts, share web links to relevant web pages. By default,
         some social media platforms shorten lengthy URLs.
       </p>
 


### PR DESCRIPTION
## What is the goal of this PR?

Previously Privacy Policy page refered to Vaticle website.
Now typedb is used when refering to the website.

## What are the changes implemented in this PR?

Updated privacy policy page content.

