### PR TITLE
Hide split pane code snippet horizontal scroll

### DIFF
--- a/website/src/framework/illustration/split-pane-illustration.component.scss
+++ b/website/src/framework/illustration/split-pane-illustration.component.scss
@@ -16,6 +16,10 @@
     z-index: 50;
     overflow: hidden;
     touch-action: none;
+
+    ::ng-deep td-code-snippet {
+        overflow-x: hidden;
+    }
 }
 
 .sp-pane:nth-of-type(2) {


### PR DESCRIPTION
## What is the goal of this PR?

Horizontal scroll was displayed when code snippet overflowed visible part of split pane.
Now horizontal scroll is never displayed for code snippet inside split pane.

## What are the changes implemented in this PR?

- A `td-code-snippet` within `split-pane-illustration` now has `overflow-x: hidden`.
