### PR TITLE
Make speaker/author profiles clearly indicated as clickable on mobile/tablet

### DIFF
--- a/website/src/framework/person-info/person-info.component.scss
+++ b/website/src/framework/person-info/person-info.component.scss
@@ -52,8 +52,7 @@
                 opacity: 1;
             }
 
-            .pi-person-name,
-            .text-quiet {
+            .pi-person-name {
                 color: inherit;
             }
         }
@@ -79,8 +78,7 @@
     a.pi-speaker {
         color: $color-vaticle-green;
 
-        .pi-person-name,
-        .text-quiet {
+        .pi-person-name {
             color: inherit;
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

Previously there was no indication that speaker/author profile is clickable.
Now text is green on mobile/tablet sized screens.

## What are the changes implemented in this PR?

- removed unused `h3` styles in person-info component,
- added green color to person text on mobile/tablet sized screens.
