### PR TITLE
Use time html element for webinar/event/blog dates

### DIFF
--- a/website/src/page/blog-page/blog-authorship-bar.component.html
+++ b/website/src/page/blog-page/blog-authorship-bar.component.html
@@ -3,4 +3,4 @@
   <strong>{{ post.author.name }}</strong>
 </p>
 <p>·</p>
-<p class="text-quiet bp-post-date">{{ post.date | date: "longDate" }}</p>
+<time class="text-quiet bp-post-date" [dateTime]="post.date">{{ post.date | date: "longDate" }}</time>

--- a/website/src/page/event-details-page/event-details-page.component.html
+++ b/website/src/page/event-details-page/event-details-page.component.html
@@ -6,7 +6,12 @@
         <li>
           <mat-icon svgIcon="calendar" />
           <span class="cdk-visually-hidden">Date/Time:</span>
-          {{ event.dateOptions | eventDate }}
+          <ng-container [ngSwitch]="!event.dateOptions.dateTBC && !!event.dateOptions.startDate">
+            <time *ngSwitchCase="true" [dateTime]="event.dateOptions.startDate!.toISOString()">
+              {{ event.dateOptions | eventDate }}
+            </time>
+            <span *ngSwitchCase="false">{{ event.dateOptions | eventDate }}</span>
+          </ng-container>
         </li>
         <li *ngIf="event.dateOptions.endDate">
           <mat-icon svgIcon="time" />

--- a/website/src/page/events-page/events-page.component.html
+++ b/website/src/page/events-page/events-page.component.html
@@ -15,7 +15,14 @@
           <h3 class="ep-event-title-container">
             <span class="ep-event-title">{{ page.featuredEvent.title | plainText }}</span>
             <span class="ep-title-separator">|</span>
-            <span>{{ page.featuredEvent.dateOptions | eventDate }}</span>
+            <ng-container
+              [ngSwitch]="!page.featuredEvent.dateOptions.dateTBC && !!page.featuredEvent.dateOptions.startDate"
+            >
+              <time *ngSwitchCase="true" [dateTime]="page.featuredEvent.dateOptions.startDate!.toISOString()">
+                {{ page.featuredEvent.dateOptions | eventDate }}
+              </time>
+              <span *ngSwitchCase="false">{{ page.featuredEvent.dateOptions | eventDate }}</span>
+            </ng-container>
             <span class="ep-title-separator">|</span>
             <span>{{ page.featuredEvent.venue }}</span>
           </h3>
@@ -37,7 +44,12 @@
             </div>
           </div>
           <div class="ep-grid-item-description text-weight-light">
-            <span>{{ event.dateOptions | eventDate }}</span>
+            <ng-container [ngSwitch]="!event.dateOptions.dateTBC && !!event.dateOptions.startDate">
+              <time *ngSwitchCase="true" [dateTime]="event.dateOptions.startDate!.toISOString()">
+                {{ event.dateOptions | eventDate }}
+              </time>
+              <span *ngSwitchCase="false">{{ event.dateOptions | eventDate }}</span>
+            </ng-container>
             <span>|</span>
             <span>{{ event.venue }}</span>
           </div>

--- a/website/src/page/webinar-details-page/webinar-details-page.component.html
+++ b/website/src/page/webinar-details-page/webinar-details-page.component.html
@@ -8,11 +8,11 @@
           <mat-icon svgIcon="calendar" />
           <span class="cdk-visually-hidden">Date/Time:</span>
           <span *ngIf="webinar.isFinished()">On-Demand</span>
-          <span *ngIf="!webinar.isFinished()">
+          <time *ngIf="!webinar.isFinished()" [dateTime]="webinar.datetime.toISOString()">
             {{ webinar.datetime | ordinalDate }},
             {{ webinar.datetime | date: "shortTime" }}
             {{ localTimezoneAbbreviation }}
-          </span>
+          </time>
         </li>
         <li>
           <mat-icon svgIcon="time" />

--- a/website/src/page/webinars-page/webinars-page.component.html
+++ b/website/src/page/webinars-page/webinars-page.component.html
@@ -17,9 +17,9 @@
               <span class="wp-webinar-title">{{ primaryWebinar.title | plainText }}</span>
               <span class="wp-title-separator">|</span>
               <span *ngIf="primaryWebinar.isFinished()">On-Demand</span>
-              <span *ngIf="!primaryWebinar.isFinished()">
+              <time *ngIf="!primaryWebinar.isFinished()" [dateTime]="primaryWebinar.datetime.toISOString()">
                 {{ primaryWebinar.datetime | ordinalDate }}
-              </span>
+              </time>
             </h3>
             <div class="wp-webinar-text-container">
               <td-rich-text class="wp-webinar-description" [value]="primaryWebinar.description" />
@@ -57,9 +57,11 @@
                   <span class="cdk-visually-hidden">Date/Time:</span>
                   <ng-container *ngIf="webinar.isFinished()">On-Demand</ng-container>
                   <ng-container *ngIf="!webinar.isFinished()">
-                    {{ webinar.datetime | ordinalDate }},
-                    {{ webinar.datetime | date: "shortTime" }}
-                    {{ localTimezoneAbbreviation(webinar) }}
+                    <time [dateTime]="webinar.datetime.toISOString()">
+                      {{ webinar.datetime | ordinalDate }},
+                      {{ webinar.datetime | date: "shortTime" }}
+                      {{ localTimezoneAbbreviation(webinar) }}
+                    </time>
                   </ng-container>
                 </span>
                 <span>


### PR DESCRIPTION
## What is the goal of this PR?

Previously dates were simple text and had no semantic meaning.
Now they use `time` tag and can be recognized by machines as datetime.

## What are the changes implemented in this PR?

Added/replaced multiple elements containing dates with time tag.
