### PR TITLE
Constrain section icons to be only SVG type in Sanity

### DIFF
--- a/schema/image.ts
+++ b/schema/image.ts
@@ -1,18 +1,39 @@
+import { getExtension } from "@sanity/asset-utils";
 import { ImageIcon } from "@sanity/icons";
 import { defineField, defineType, SanityDocument } from "@sanity/types";
+
 import { titleField } from "./common-fields";
-import { SanityImageAsset, SanityReference } from "./sanity-core";
+import { SanityImage } from "./sanity-core";
 
 export const assetRefFieldName = "assetRef";
 
 export interface SanityImageRef extends SanityDocument {
-    assetRef: { asset: SanityReference<SanityImageAsset> };
+    [assetRefFieldName]: SanityImage;
 }
 
 const assetRefField = defineField({
     name: assetRefFieldName,
     title: "Image",
     type: "image",
+});
+
+const svgRefField = defineField({
+    ...assetRefField,
+    options: { accept: "image/svg+xml" },
+    validation: (rule) =>
+        rule.custom((value) => {
+            if (!value?.asset) {
+                return true;
+            }
+
+            const filetype = getExtension(value.asset._ref);
+
+            if (filetype !== "svg") {
+                return "Image must be an SVG";
+            }
+
+            return true;
+        }),
 });
 
 const imageRefSchemaBase = defineType({
@@ -24,7 +45,12 @@ const imageRefSchemaBase = defineType({
 
 export const sectionIconSchemaName = "sectionIcon";
 
-const sectionIconSchema = Object.assign({}, imageRefSchemaBase, { name: sectionIconSchemaName, title: "Section Icon" });
+const sectionIconSchema = defineType({
+    ...imageRefSchemaBase,
+    fields: [titleField, svgRefField],
+    name: sectionIconSchemaName,
+    title: "Section Icon",
+});
 
 export const headshotSchemaName = "headshot";
 

--- a/schema/package.json
+++ b/schema/package.json
@@ -5,6 +5,7 @@
     "main": "index.ts",
     "license": "UNLICENSED",
     "devDependencies": {
+        "@sanity/asset-utils": "1.3.0",
         "@sanity/icons": "2.4.1",
         "@sanity/types": "3.14.1",
         "@types/react": "18.0.28",

--- a/schema/pnpm-lock.yaml
+++ b/schema/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 devDependencies:
+  '@sanity/asset-utils':
+    specifier: 1.3.0
+    version: 1.3.0
   '@sanity/icons':
     specifier: 2.4.1
     version: 2.4.1(react@18.2.0)
@@ -22,6 +25,11 @@ devDependencies:
     version: 4.7.4
 
 packages:
+
+  /@sanity/asset-utils@1.3.0:
+    resolution: {integrity: sha512-uyIOtGA4Duf+68I3BSbYHY5P+WGftn3QtNJD2Pn7h9WPGYsSrWViIPebE9yRN8N0NHhYj+hDQXaMpVdjG7r+zA==}
+    engines: {node: '>=10'}
+    dev: true
 
   /@sanity/client@6.1.7:
     resolution: {integrity: sha512-crleZDBic3VpmBhIuiVZNkJMxAWE/fj5v+hHBXt+2psW1CJrvBdTLX14f4cqC40W1YDDE4ZGrDkYuph6Y6/YzQ==}


### PR DESCRIPTION
## What is the goal of this PR?

Previously any image could be used as a section icon.
Now image picker accepts svg and there is validation to allow svg only.

## What are the changes implemented in this PR?

- added `@sanity/asset-utils` package to use `getExtension` helper,
- added accept type and validation to section icon schema.