### PR TITLE
Fix illustration image size on Safari

### DIFF
--- a/website/src/framework/illustration/illustration.component.scss
+++ b/website/src/framework/illustration/illustration.component.scss
@@ -2,7 +2,8 @@
 @import "../../styles/sizes";
 
 :host {
-    display: block;
+    display: flex;
+    flex-direction: column;
     border-radius: $border-radius;
     position: relative;
     overflow: hidden;


### PR DESCRIPTION
## What is the goal of this PR?

Previously image overflowed container on Safari.
Now it shows as on Chrome

## What are the changes implemented in this PR?

Due to Safari bug/behaviour browser can't resolve 100% of height, flex container fixes this behaviour.
