### PR TITLE
Make navigation work properly when a Link object contains a hash

### DIFF
--- a/website/src/framework/technicolor-block/technicolor-block.component.ts
+++ b/website/src/framework/technicolor-block/technicolor-block.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, DestroyRef, ElementRef, Input } from "@angular/core";
+import { AfterViewInit, Component, DestroyRef, ElementRef, Input, NgZone } from "@angular/core";
 import { Organisation, TechnicolorBlock } from "typedb-web-schema";
 
 @Component({
@@ -22,13 +22,16 @@ export class TechnicolorBlockComponent implements AfterViewInit {
     constructor(
         private destroyRef: DestroyRef,
         private elementRef: ElementRef<HTMLElement>,
+        private ngZone: NgZone,
     ) {}
 
     ngAfterViewInit(): void {
-        const { cleanupDotListeners } = this.initDotListeners();
-        this.destroyRef.onDestroy(() => {
-            cleanupDotListeners();
-        });
+        // this.ngZone.runOutsideAngular(() => {
+        //     const { cleanupDotListeners } = this.initDotListeners();
+        //     this.destroyRef.onDestroy(() => {
+        //         cleanupDotListeners();
+        //     });
+        // });
     }
 
     get graphicColorClass(): string {


### PR DESCRIPTION
## What is the goal of this PR?

Previously hash fragments in link were treated as part of the path and were escaped with `%23`.
Now they are correctly treated as fragments and navigate to correct link.

## What are the changes implemented in this PR?

LinkDirective is changed to support hash fragment.

Also fixed one listener that caused too many renders for majority of pages.