### PR TITLE
Make meta tags configurable per page

### DIFF
--- a/schema/event-base.ts
+++ b/schema/event-base.ts
@@ -3,7 +3,7 @@ import { Person, SanityPerson } from "./person";
 import { SanityDataset, SanityImage, SanityReference } from "./sanity-core";
 import { ParagraphWithHighlights, RichText, SanityPortableText } from "./text";
 import { PropsOf } from "./util";
-import { MetaTags, SanityMetaTags } from "./page/common";
+import { MetaTags, SanityMetaTags } from "./page/meta-tags";
 
 export interface SanityEventBase extends SanityDocument {
     title: SanityPortableText;

--- a/schema/event.ts
+++ b/schema/event.ts
@@ -9,7 +9,7 @@ import { Link } from "./link";
 import { personSchemaName } from "./person";
 import { SanityDataset } from "./sanity-core";
 import { PropsOf } from "./util";
-import { metaTagsField } from "./page/common";
+import { metaTagsField } from "./page/meta-tags";
 
 enum SignupMethod {
     externalURL = "externalURL",

--- a/schema/index.ts
+++ b/schema/index.ts
@@ -54,7 +54,8 @@ export { type SanitySiteBanner, SiteBanner, siteBannerSchemaName } from "./navig
 export { type SanityTopbar, Topbar, TopbarListColumn, TopbarListColumnItem, TopbarMenuPanel, topbarSchemaName, TopbarVideoColumn } from "./navigation/topbar";
 export { Organisation, organisationSchemaName, type SanityOrganisation } from "./organisation";
 export { GenericPage, type SanityGenericPage, genericPageSchemaName } from "./page/generic";
-export { Page, type SanityPage, MetaTags, type SanityMetaTags } from "./page/common";
+export { Page, type SanityPage } from "./page/common";
+export { MetaTags, type SanityMetaTags } from "./page/meta-tags";
 export { DeploymentPage, type SanityDeploymentPage, deploymentPageSchemaName } from "./page/deployment";
 export { EventsPage, type SanityEventsPage, eventsPageSchemaName } from "./page/events";
 export { FeaturesPage, featuresPageSchemaName, type SanityFeaturesPage } from "./page/features";

--- a/schema/page/common.ts
+++ b/schema/page/common.ts
@@ -1,8 +1,7 @@
 import { BlockContentIcon } from "@sanity/icons";
-import { defineField, defineType, SanityDocument } from "@sanity/types";
-import { Document, SanityDataset, SanityImage } from "../sanity-core";
-import { PropsOf } from "../util";
-import { collapsibleOptions, requiredRule } from "../common-fields";
+import { defineType, SanityDocument } from "@sanity/types";
+import { Document, SanityDataset } from "../sanity-core";
+import { MetaTags, SanityMetaTags } from "./meta-tags";
 
 export interface SanityPage extends SanityDocument {
     title: string;
@@ -26,72 +25,6 @@ const bodyTextSchema = defineType({
     icon: BlockContentIcon,
     type: "array",
     of: [{ type: "block" }],
-});
-
-export interface SanityMetaTags {
-    description?: string;
-    keywords?: string[];
-    ogImage?: SanityImage;
-    custom?: { property: string; content: string }[];
-}
-
-export class MetaTags {
-    readonly description?: string;
-    readonly keywords?: string[];
-    readonly ogImage?: string;
-    readonly custom: { property: string; content: string }[];
-
-    protected constructor(data: PropsOf<MetaTags>) {
-        this.description = data.description;
-        this.keywords = data.keywords;
-        this.ogImage = data.ogImage;
-        this.custom = data.custom;
-    }
-
-    static fromSanity(data: SanityMetaTags, db: SanityDataset) {
-        return new MetaTags({
-            description: data.description,
-            keywords: data.keywords,
-            ogImage: data.ogImage && db.resolveRef(data.ogImage.asset).url,
-            custom: data.custom?.map(({ content, property }) => ({ content, property })) || [],
-        });
-    }
-}
-
-const customMetaTagsField = defineField({
-    title: "Custom",
-    name: "custom",
-    type: "array",
-    of: [
-        {
-            type: "object",
-            fields: [
-                { name: "property", type: "string", validation: requiredRule },
-                { name: "content", type: "string", validation: requiredRule },
-            ],
-            preview: {
-                select: {
-                    title: "property",
-                    subtitle: "content",
-                },
-            },
-        },
-    ],
-});
-
-export const metaTagsFieldName = "metaTags";
-
-export const metaTagsField = defineField({
-    title: "Meta Tags",
-    name: metaTagsFieldName,
-    type: "object",
-    fields: [
-        { name: "description", type: "text" },
-        { name: "keywords", type: "array", of: [{ type: "string" }], options: { layout: "tags" } },
-        { name: "ogImage", title: "Image", type: "image" },
-        customMetaTagsField,
-    ],
-    options: collapsibleOptions,
 });
 
 export const basePageSchemas = [bodyTextSchema];

--- a/schema/page/deployment.ts
+++ b/schema/page/deployment.ts
@@ -15,7 +15,8 @@ import { ProductPanel, productPanelSchemaName, SanityProductPanel } from "../com
 import { SanityTechnicolorBlock, TechnicolorBlock } from "../component/technicolor-block";
 import { SanityDataset } from "../sanity-core";
 import { PropsOf } from "../util";
-import { metaTagsField, Page, SanityPage } from "./common";
+import { Page, SanityPage } from "./common";
+import { metaTagsField } from "./meta-tags";
 
 export interface SanityDeploymentPage extends SanityPage {
     introSection: SanityIntroSection;

--- a/schema/page/events.ts
+++ b/schema/page/events.ts
@@ -4,7 +4,8 @@ import { collapsibleOptions, isVisibleField, pageTitleField, requiredRule } from
 import { Event, SanityEvent, eventSchemaName } from "../event";
 import { SanityDataset, SanityReference } from "../sanity-core";
 import { SanityTitleAndBody, TitleAndBody, titleAndBodySchemaName } from "../text";
-import { Page, SanityPage, metaTagsField } from "./common";
+import { Page, SanityPage } from "./common";
+import { metaTagsField } from "./meta-tags";
 
 interface SanityEventsListSection {
     isVisible: boolean;

--- a/schema/page/features.ts
+++ b/schema/page/features.ts
@@ -12,7 +12,8 @@ import { Organisation, organisationLogosField, SanityOrganisation } from "../org
 import { SanityDataset, SanityReference } from "../sanity-core";
 import { SanityTitleBodyActions, TitleBodyActions } from "../text";
 import { PropsOf } from "../util";
-import { Page, SanityPage, metaTagsField } from "./common";
+import { Page, SanityPage } from "./common";
+import { metaTagsField } from "./meta-tags";
 
 const introSection = "introSection";
 const featureSections = "featureSections";

--- a/schema/page/generic.ts
+++ b/schema/page/generic.ts
@@ -10,7 +10,8 @@ import {
     TitleBodyIllustrationSection,
     titleBodyIllustrationSectionSchemaName,
 } from "../text";
-import { Page, SanityPage, metaTagsField } from "./common";
+import { Page, SanityPage } from "./common";
+import { metaTagsField } from "./meta-tags";
 
 export interface SanityGenericPage extends SanityPage {
     introSection: SanityTitleBodyActions;

--- a/schema/page/home.ts
+++ b/schema/page/home.ts
@@ -36,7 +36,8 @@ import { SanityTestimonial, Testimonial, testimonialSchemaName } from "../testim
 import { SanityTitleBodyActions } from "../text";
 import { PropsOf } from "../util";
 
-import { Page, SanityPage, metaTagsField } from "./common";
+import { Page, SanityPage } from "./common";
+import { metaTagsField } from "./meta-tags";
 
 const sections = {
     intro: { id: "introSection", title: "Intro" },

--- a/schema/page/index.ts
+++ b/schema/page/index.ts
@@ -11,6 +11,7 @@ import { solutionPageSchemas } from "./solution";
 import { supportPageSchemas } from "./support";
 import { webinarsPageSchemas } from "./webinars";
 import { whitePapersPageSchema } from "./white-papers";
+import { metaTagsSchemas } from "./meta-tags";
 
 export const pageSchemas = [
     ...basePageSchemas,
@@ -26,4 +27,5 @@ export const pageSchemas = [
     ...webinarsPageSchemas,
     requestTechTalkPageSchema,
     whitePapersPageSchema,
+    ...metaTagsSchemas,
 ];

--- a/schema/page/intro.ts
+++ b/schema/page/intro.ts
@@ -22,7 +22,8 @@ import {
     TitleBodyActions,
 } from "../text";
 import { PropsOf } from "../util";
-import { Page, SanityPage, metaTagsField } from "./common";
+import { Page, SanityPage } from "./common";
+import { metaTagsField } from "./meta-tags";
 
 export interface SanityIntroPage extends SanityPage {
     introSection: SanityTitleBodyActions;

--- a/schema/page/meta-tags.ts
+++ b/schema/page/meta-tags.ts
@@ -1,0 +1,75 @@
+import { defineField } from "@sanity/types";
+import { collapsibleOptions, requiredRule } from "../common-fields";
+import { SanityDataset, SanityImage } from "../sanity-core";
+import { PropsOf } from "../util";
+
+export interface SanityMetaTags {
+    description?: string;
+    keywords?: string[];
+    ogImage?: SanityImage;
+    custom?: { property: string; content: string }[];
+}
+
+export class MetaTags {
+    readonly description?: string;
+    readonly keywords?: string[];
+    readonly ogImage?: string;
+    readonly custom: { property: string; content: string }[];
+
+    protected constructor(data: PropsOf<MetaTags>) {
+        this.description = data.description;
+        this.keywords = data.keywords;
+        this.ogImage = data.ogImage;
+        this.custom = data.custom;
+    }
+
+    static fromSanity(data: SanityMetaTags, db: SanityDataset) {
+        return new MetaTags({
+            description: data.description,
+            keywords: data.keywords,
+            ogImage: data.ogImage && db.resolveRef(data.ogImage.asset).url,
+            custom: data.custom?.map(({ content, property }) => ({ content, property })) || [],
+        });
+    }
+}
+
+export const customMetaTagFieldName = "customMetaTag";
+
+export const customMetaTagFieldSchema = defineField({
+    type: "object",
+    name: customMetaTagFieldName,
+    fields: [
+        { name: "property", type: "string", validation: requiredRule },
+        { name: "content", type: "string", validation: requiredRule },
+    ],
+    preview: {
+        select: {
+            title: "property",
+            subtitle: "content",
+        },
+    },
+});
+
+const customMetaTagsField = defineField({
+    title: "Custom",
+    name: "custom",
+    type: "array",
+    of: [{ type: customMetaTagFieldName }],
+});
+
+export const metaTagsFieldName = "metaTags";
+
+export const metaTagsField = defineField({
+    title: "Meta Tags",
+    name: metaTagsFieldName,
+    type: "object",
+    fields: [
+        { name: "description", type: "text" },
+        { name: "keywords", type: "array", of: [{ type: "string" }], options: { layout: "tags" } },
+        { name: "ogImage", title: "Image", type: "image" },
+        customMetaTagsField,
+    ],
+    options: collapsibleOptions,
+});
+
+export const metaTagsSchemas = [customMetaTagFieldSchema];

--- a/schema/page/request-tech-talk.ts
+++ b/schema/page/request-tech-talk.ts
@@ -1,6 +1,6 @@
 import { defineField, defineType } from "@sanity/types";
 
-import { Page, SanityPage, metaTagsField } from "./common";
+import { Page, SanityPage } from "./common";
 import { collapsibleOptions, pageTitleField, titleFieldWithHighlights } from "../common-fields";
 import { hubspotFormIDField } from "../form";
 import {
@@ -12,6 +12,7 @@ import {
     titleAndBodySchemaName,
 } from "../text";
 import { SanityDataset } from "../sanity-core";
+import { metaTagsField } from "./meta-tags";
 
 export interface SanityRequestTechTalkPage extends SanityPage {
     introTitle: SanityPortableText;

--- a/schema/page/services.ts
+++ b/schema/page/services.ts
@@ -14,8 +14,9 @@ import { SanityDataset, SanityReference } from "../sanity-core";
 import { SanityTestimonial, Testimonial, testimonialSchemaName } from "../testimonial";
 import { SanityTitleBodyActions } from "../text";
 import { PropsOf } from "../util";
-import { Page, SanityPage, metaTagsField } from "./common";
+import { Page, SanityPage } from "./common";
 import { SanityServicesKeyPoint, ServicesKeyPoint, servicesKeyPointSchemaName } from "../key-point";
+import { metaTagsField } from "./meta-tags";
 
 const sections = {
     intro: { id: "introSection", title: "Intro" },

--- a/schema/page/solution.ts
+++ b/schema/page/solution.ts
@@ -32,7 +32,8 @@ import {
     TitleAndBody,
 } from "../text";
 import { PropsOf } from "../util";
-import { metaTagsField, Page, SanityPage } from "./common";
+import { Page, SanityPage } from "./common";
+import { metaTagsField } from "./meta-tags";
 
 const sections = {
     intro: { id: "introSection", title: "Intro" },

--- a/schema/page/support.ts
+++ b/schema/page/support.ts
@@ -17,7 +17,8 @@ import { SanityDataset, SanityReference } from "../sanity-core";
 import { SanityTestimonial, Testimonial, testimonialSchemaName } from "../testimonial";
 import { SanityTitleBodyActions } from "../text";
 import { PropsOf } from "../util";
-import { Page, SanityPage, metaTagsField } from "./common";
+import { Page, SanityPage } from "./common";
+import { metaTagsField } from "./meta-tags";
 
 const sections = {
     intro: { id: "introSection", title: "Intro" },

--- a/schema/page/webinars.ts
+++ b/schema/page/webinars.ts
@@ -14,7 +14,8 @@ import { SanityDataset, SanityReference } from "../sanity-core";
 import { SanityTitleAndBody, TitleAndBody } from "../text";
 import { PropsOf } from "../util";
 import { SanityWebinar, Webinar, webinarSchemaName } from "../webinar";
-import { Page, SanityPage, metaTagsField } from "./common";
+import { Page, SanityPage } from "./common";
+import { metaTagsField } from "./meta-tags";
 
 export interface SanityWebinarsPage extends SanityPage {
     introSection: SanityIntroSection;

--- a/schema/page/white-papers.ts
+++ b/schema/page/white-papers.ts
@@ -2,9 +2,9 @@ import { ArrayRule, defineField, defineType } from "@sanity/types";
 import { collapsibleOptions, pageTitleField } from "../common-fields";
 import { SanityDataset, SanityReference } from "../sanity-core";
 import { SanityTitleAndBody, TitleAndBody, titleAndBodySchemaName } from "../text";
-import { PropsOf } from "../util";
 import { SanityWhitePaper, WhitePaper, whitePaperSchemaName } from "../white-paper";
-import { Page, SanityPage, metaTagsField } from "./common";
+import { Page, SanityPage } from "./common";
+import { metaTagsField } from "./meta-tags";
 
 export interface SanityWhitePapersPage extends SanityPage {
     introSection: SanityTitleAndBody;

--- a/schema/webinar.ts
+++ b/schema/webinar.ts
@@ -19,7 +19,7 @@ import { personSchemaName } from "./person";
 import { SanityDataset } from "./sanity-core";
 import { PropsOf } from "./util";
 import { EventBase, SanityEventBase } from "./event-base";
-import { metaTagsField } from "./page/common";
+import { metaTagsField } from "./page/meta-tags";
 
 export interface SanityWebinar extends SanityEventBase {
     datetime: string;

--- a/schema/white-paper.ts
+++ b/schema/white-paper.ts
@@ -11,7 +11,7 @@ import { Link } from "./link";
 import { SanityDataset, SanityFile, SanityImage } from "./sanity-core";
 import { ParagraphWithHighlights, RichText, SanityPortableText } from "./text";
 import { PropsOf } from "./util";
-import { MetaTags, metaTagsField, SanityMetaTags } from "./page/common";
+import { MetaTags, metaTagsField, SanityMetaTags } from "./page/meta-tags";
 
 export interface SanityWhitePaper extends SanityDocument {
     title: SanityPortableText;

--- a/website/src/page/deployment-page/deployment-page.component.ts
+++ b/website/src/page/deployment-page/deployment-page.component.ts
@@ -31,7 +31,8 @@ export class DeploymentPageComponent implements OnInit {
             if (sanityDeploymentPage) {
                 this.page = new DeploymentPage(sanityDeploymentPage, data);
                 this._title.setTitle(`${this.page.title} - TypeDB`);
-                this.metaTags.register(this.page.metaTags, this.destroyRef);
+                const { unregister } = this.metaTags.register(this.page.metaTags);
+                this.destroyRef.onDestroy(unregister);
                 this._analytics.hubspot.trackPageView();
                 setTimeout(() => {
                     this._idleMonitor.fireManualMyAppReadyEvent();

--- a/website/src/page/event-details-page/event-details-page.component.ts
+++ b/website/src/page/event-details-page/event-details-page.component.ts
@@ -34,6 +34,8 @@ export class EventDetailsPageComponent implements OnInit {
     ) {}
 
     ngOnInit() {
+        let unregisterMetaTags = () => {};
+        this.destroyRef.onDestroy(() => unregisterMetaTags());
         this.event$ = combineLatest([this.activatedRoute.paramMap, this.contentService.data]).pipe(
             map(([params, data]) => {
                 const sanityEvents = data.getDocumentsByType(eventSchemaName) as SanityEvent[];
@@ -43,7 +45,9 @@ export class EventDetailsPageComponent implements OnInit {
             tap((event) => {
                 if (event) {
                     this.title.setTitle(`${this.plainTextPipe.transform(event.title)} - TypeDB Events`);
-                    this.metaTags.register(event.metaTags, this.destroyRef);
+                    unregisterMetaTags();
+                    const { unregister } = this.metaTags.register(event.metaTags);
+                    unregisterMetaTags = unregister;
                     this.analytics.hubspot.trackPageView();
                     setTimeout(() => {
                         this.idleMonitor.fireManualMyAppReadyEvent();

--- a/website/src/page/events-page/events-page.component.ts
+++ b/website/src/page/events-page/events-page.component.ts
@@ -38,7 +38,8 @@ export class EventsPageComponent implements OnInit {
             tap((page) => {
                 if (page) {
                     this.title.setTitle(`${page.title} - TypeDB`);
-                    this.metaTags.register(page.metaTags, this.destroyRef);
+                    const { unregister } = this.metaTags.register(page.metaTags);
+                    this.destroyRef.onDestroy(unregister);
                     this.analytics.hubspot.trackPageView();
                     setTimeout(() => {
                         this.idleMonitor.fireManualMyAppReadyEvent();

--- a/website/src/page/features-page/features-page.component.ts
+++ b/website/src/page/features-page/features-page.component.ts
@@ -32,7 +32,8 @@ export class FeaturesPageComponent implements OnInit {
             if (sanityFeaturesPage) {
                 this.page = new FeaturesPage(sanityFeaturesPage, data);
                 this._title.setTitle(`${this.page.title} - TypeDB`);
-                this.metaTags.register(this.page.metaTags, this.destroyRef);
+                const { unregister } = this.metaTags.register(this.page.metaTags);
+                this.destroyRef.onDestroy(unregister);
                 this._analytics.hubspot.trackPageView();
                 setTimeout(() => {
                     this._idleMonitor.fireManualMyAppReadyEvent();

--- a/website/src/page/generic-page/generic-page.component.ts
+++ b/website/src/page/generic-page/generic-page.component.ts
@@ -33,7 +33,8 @@ export class GenericPageComponent implements OnInit {
                 if (sanityCloudPage) {
                     this.page = new GenericPage(sanityCloudPage, data);
                     this._title.setTitle(`${this.page.title} - TypeDB`);
-                    this.metaTags.register(this.page.metaTags, this.destroyRef);
+                    const { unregister } = this.metaTags.register(this.page.metaTags);
+                    this.destroyRef.onDestroy(unregister);
                     this._analytics.hubspot.trackPageView();
                     setTimeout(() => {
                         this._idleMonitor.fireManualMyAppReadyEvent();

--- a/website/src/page/home-page/home-page.component.ts
+++ b/website/src/page/home-page/home-page.component.ts
@@ -35,7 +35,8 @@ export class HomePageComponent implements OnInit {
             if (sanityHomePage) {
                 this.page = new HomePage(sanityHomePage, data);
                 this._title.setTitle(`${this.page.title} - TypeDB`);
-                this.metaTags.register(this.page.metaTags, this.destroyRef);
+                const { unregister } = this.metaTags.register(this.page.metaTags);
+                this.destroyRef.onDestroy(unregister);
                 this.socialMediaLinks = this.page.communitySection?.socialMedias.map(
                     (x) => new SocialMediaLink(x, data),
                 );

--- a/website/src/page/intro-page/intro-page.component.ts
+++ b/website/src/page/intro-page/intro-page.component.ts
@@ -38,7 +38,8 @@ export class IntroPageComponent implements OnInit {
             if (sanityIntroPage) {
                 this.page = new IntroPage(sanityIntroPage, data);
                 this._title.setTitle(`${this.page.title} - TypeDB`);
-                this.metaTags.register(this.page.metaTags, this.destroyRef);
+                const { unregister } = this.metaTags.register(this.page.metaTags);
+                this.destroyRef.onDestroy(unregister);
                 this._analytics.hubspot.trackPageView();
                 setTimeout(() => {
                     this._idleMonitor.fireManualMyAppReadyEvent();

--- a/website/src/page/request-tech-talk-page/request-tech-talk-page.component.ts
+++ b/website/src/page/request-tech-talk-page/request-tech-talk-page.component.ts
@@ -39,7 +39,8 @@ export class RequestTechTalkPageComponent implements OnInit {
             if (sanityRequestTechTalkPage) {
                 this.page = new RequestTechTalkPage(sanityRequestTechTalkPage, data);
                 this.title.setTitle(`${this.page.title} - TypeDB`);
-                this.metaTags.register(this.page.metaTags, this.destroyRef);
+                const { unregister } = this.metaTags.register(this.page.metaTags);
+                this.destroyRef.onDestroy(unregister);
                 this.analytics.hubspot.trackPageView();
                 setTimeout(() => {
                     this.idleMonitor.fireManualMyAppReadyEvent();

--- a/website/src/page/services-page/services-page.component.ts
+++ b/website/src/page/services-page/services-page.component.ts
@@ -37,7 +37,8 @@ export class ServicesPageComponent implements OnInit {
             tap((page) => {
                 if (page) {
                     this.title.setTitle(`${page.title} - TypeDB`);
-                    this.metaTags.register(page.metaTags, this.destroyRef);
+                    const { unregister } = this.metaTags.register(page.metaTags);
+                    this.destroyRef.onDestroy(unregister);
                     this.analytics.hubspot.trackPageView();
                     setTimeout(() => {
                         this.idleMonitor.fireManualMyAppReadyEvent();

--- a/website/src/page/solution-page/solution-page.component.ts
+++ b/website/src/page/solution-page/solution-page.component.ts
@@ -35,7 +35,8 @@ export class SolutionPageComponent implements OnInit {
                 if (sanitySolutionPage) {
                     this.page = new SolutionPage(sanitySolutionPage, data);
                     this._title.setTitle(`${this.page.title} - TypeDB Solutions`);
-                    this.metaTags.register(this.page.metaTags, this.destroyRef);
+                    const { unregister } = this.metaTags.register(this.page.metaTags);
+                    this.destroyRef.onDestroy(unregister);
                     this._analytics.hubspot.trackPageView();
                     setTimeout(() => {
                         this._idleMonitor.fireManualMyAppReadyEvent();

--- a/website/src/page/support-page/support-page.component.ts
+++ b/website/src/page/support-page/support-page.component.ts
@@ -36,7 +36,8 @@ export class SupportPageComponent implements OnInit {
             tap((page) => {
                 if (page) {
                     this.title.setTitle(`${page.title} - TypeDB`);
-                    this.metaTags.register(page.metaTags, this.destroyRef);
+                    const { unregister } = this.metaTags.register(page.metaTags);
+                    this.destroyRef.onDestroy(unregister);
                     this.analytics.hubspot.trackPageView();
                     setTimeout(() => {
                         this.idleMonitor.fireManualMyAppReadyEvent();

--- a/website/src/page/webinar-details-page/webinar-details-page.component.ts
+++ b/website/src/page/webinar-details-page/webinar-details-page.component.ts
@@ -36,6 +36,8 @@ export class WebinarDetailsPageComponent implements OnInit {
     ) {}
 
     ngOnInit() {
+        let unregisterMetaTags = () => {};
+        this.destroyRef.onDestroy(() => unregisterMetaTags());
         this._activatedRoute.paramMap.subscribe((params: ParamMap) => {
             this.contentService.data.subscribe((data) => {
                 const sanityWebinars = data.getDocumentsByType(webinarSchemaName) as SanityWebinar[];
@@ -45,7 +47,9 @@ export class WebinarDetailsPageComponent implements OnInit {
                 if (sanityWebinar) {
                     this.webinar = Webinar.fromSanity(sanityWebinar, data);
                     this._title.setTitle(`${this._plainTextPipe.transform(this.webinar.title)} - TypeDB Webinars`);
-                    this.metaTags.register(this.webinar.metaTags, this.destroyRef);
+                    unregisterMetaTags();
+                    const { unregister } = this.metaTags.register(this.webinar.metaTags);
+                    unregisterMetaTags = unregister;
                     this._analytics.hubspot.trackPageView();
                     setTimeout(() => {
                         this._idleMonitor.fireManualMyAppReadyEvent();

--- a/website/src/page/webinars-page/webinars-page.component.ts
+++ b/website/src/page/webinars-page/webinars-page.component.ts
@@ -40,7 +40,8 @@ export class WebinarsPageComponent implements OnInit {
             if (sanityWebinarsPage) {
                 this.page = new WebinarsPage(sanityWebinarsPage, data);
                 this._title.setTitle(`${this.page.title} - TypeDB`);
-                this.metaTags.register(this.page.metaTags, this.destroyRef);
+                const { unregister } = this.metaTags.register(this.page.metaTags);
+                this.destroyRef.onDestroy(unregister);
                 this._analytics.hubspot.trackPageView();
                 setTimeout(() => {
                     this._idleMonitor.fireManualMyAppReadyEvent();

--- a/website/src/page/white-paper-details-page/white-paper-details-page.component.ts
+++ b/website/src/page/white-paper-details-page/white-paper-details-page.component.ts
@@ -34,6 +34,8 @@ export class WhitePaperDetailsPageComponent implements OnInit {
     ) {}
 
     ngOnInit() {
+        let unregisterMetaTags = () => {};
+        this.destroyRef.onDestroy(() => unregisterMetaTags());
         this._activatedRoute.paramMap.subscribe((params: ParamMap) => {
             this.contentService.data.subscribe((data) => {
                 const sanityWhitePapers = data.getDocumentsByType(whitePaperSchemaName) as SanityWhitePaper[];
@@ -43,7 +45,9 @@ export class WhitePaperDetailsPageComponent implements OnInit {
                     this._title.setTitle(
                         `${this._plainTextPipe.transform(this.whitePaper.title)} - TypeDB White Papers`,
                     );
-                    this.metaTags.register(this.whitePaper.metaTags, this.destroyRef);
+                    unregisterMetaTags();
+                    const { unregister } = this.metaTags.register(this.whitePaper.metaTags);
+                    unregisterMetaTags = unregister;
                     this._analytics.hubspot.trackPageView();
                     this._formService.embedHubspotForm(this.whitePaper.hubspotFormID, "hubspot-form-holder", {
                         onLoadingChange: (val) => {

--- a/website/src/page/white-papers-page/white-papers-page.component.ts
+++ b/website/src/page/white-papers-page/white-papers-page.component.ts
@@ -38,7 +38,8 @@ export class WhitePapersPageComponent implements OnInit {
             if (sanityWhitePapersPage) {
                 this.page = new WhitePapersPage(sanityWhitePapersPage, data);
                 this._title.setTitle(`${this.page.title} - TypeDB`);
-                this.metaTags.register(this.page.metaTags, this.destroyRef);
+                const { unregister } = this.metaTags.register(this.page.metaTags);
+                this.destroyRef.onDestroy(unregister);
                 this._analytics.hubspot.trackPageView();
                 setTimeout(() => {
                     this._idleMonitor.fireManualMyAppReadyEvent();

--- a/website/src/service/meta-tags.service.ts
+++ b/website/src/service/meta-tags.service.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, Injectable, Injector } from "@angular/core";
+import { Injectable } from "@angular/core";
 import { Meta, MetaDefinition } from "@angular/platform-browser";
 import { MetaTags } from "typedb-web-schema";
 
@@ -8,7 +8,7 @@ import { MetaTags } from "typedb-web-schema";
 export class MetaTagsService {
     constructor(private meta: Meta) {}
 
-    register(metaTags: MetaTags, destroyRef: DestroyRef) {
+    register(metaTags: MetaTags) {
         const metaDefinitions: MetaDefinition[] = [];
         if (metaTags.description) {
             metaDefinitions.push({ name: "description", content: metaTags.description });
@@ -22,6 +22,7 @@ export class MetaTagsService {
         metaTags.custom.forEach(({ property, content }) => metaDefinitions.push({ property, content }));
 
         const tags = this.meta.addTags(metaDefinitions, true);
-        destroyRef.onDestroy(() => tags.forEach((tag) => this.meta.removeTagElement(tag)));
+
+        return { unregister: () => tags.forEach((tag) => this.meta.removeTagElement(tag)) };
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

Previously meta tags were not set and there was no way to set them.
Now "description", "keywords", "og:image" and custom tags can be set in cms.

## What are the changes implemented in this PR?

Implemented new meta tags field and added it two every sanity page.
Added meta tags service and used it in every page from sanity.