### PR TITLE
Blog: redirect invalid article URLs to main blog home page

### DIFF
--- a/website/src/page/blog-page/blog-post-page.component.ts
+++ b/website/src/page/blog-page/blog-post-page.component.ts
@@ -91,14 +91,14 @@ export class BlogPostPageComponent implements OnInit {
                     this.postContentEl.nativeElement.innerHTML = post!.content;
                     Prism.highlightAll();
                 } else {
-                    this.router.navigate(["404"], { skipLocationChange: true });
+                    this.router.navigate(["blog"]);
                 }
                 setTimeout(() => {
                     this._idleMonitor.fireManualMyAppReadyEvent();
                 }, 15000);
             },
             (_err) => {
-                this.router.navigate(["404"], { skipLocationChange: true });
+                this.router.navigate(["blog"]);
             },
         );
     }


### PR DESCRIPTION
## What is the goal of this PR?

Previously when user visited blog with missing slug it displayed 404 page.
Now invalid article page is redirected to main blog home page.

## What are the changes implemented in this PR?

Changed missing blog post navigation to main blog page.
