### PR TITLE
Contain blurring of code snippet inside borders

### DIFF
--- a/website/src/framework/feature-grid/feature-grid.component.scss
+++ b/website/src/framework/feature-grid/feature-grid.component.scss
@@ -166,9 +166,12 @@
 }
 
 .kpt-blur {
-    filter: blur(4px);
     user-select: none;
     overflow: hidden !important;
+
+    > * {
+        filter: blur(4px);
+    }
 }
 
 .kpt-code-short {

--- a/website/src/framework/illustration/illustration.component.scss
+++ b/website/src/framework/illustration/illustration.component.scss
@@ -17,8 +17,11 @@
     }
 
     &.il-blur {
-        filter: blur(5px);
         user-select: none;
+
+        > * {
+            filter: blur(5px);
+        }
     }
 }
 


### PR DESCRIPTION
## What is the goal of this PR?

Previously blurred code snippet was making border appear blurred as well.
Now it's changed so blur applies only to the content inside borders.

## What are the changes implemented in this PR?

Moved blur from container to children elements.
