### PR TITLE
Adds missing feature grid separator

### DIFF
--- a/website/src/framework/feature-grid/feature-grid.component.scss
+++ b/website/src/framework/feature-grid/feature-grid.component.scss
@@ -17,6 +17,11 @@
             height: unset !important;
             margin-bottom: 16px;
         }
+
+        td:not(:first-child) {
+            border-left: 0;
+            border-top: 1px solid $color-vaticle-light-purple;
+        }
     }
 
     tr {


### PR DESCRIPTION
## What is the goal of this PR?

There was missing separator on feature grid on mobile view.
Now all separators are correctly displayed.

## What are the changes implemented in this PR?

- overrides border styles for mobiles.