### PR TITLE
Fix success message of contact form overlapping privacy policy notice

### DIFF
--- a/website/src/framework/contact-panel/contact-panel.component.html
+++ b/website/src/framework/contact-panel/contact-panel.component.html
@@ -1,8 +1,8 @@
 <div [id]="formHolderId"></div>
 <div class="cp-contact-policy">
-  <p>
+  <aside>
     By submitting your personal data, you consent to emails from Vaticle. See our
     <a href="/privacy-policy" target="_blank">Privacy Policy</a>.
-  </p>
+  </aside>
 </div>
 <mat-progress-bar *ngIf="isSubmitting" mode="indeterminate" />

--- a/website/src/framework/contact-panel/contact-panel.component.scss
+++ b/website/src/framework/contact-panel/contact-panel.component.scss
@@ -4,21 +4,28 @@
     display: block;
     padding: 32px;
     position: relative;
+
+    ::ng-deep .submitted-message {
+        margin-bottom: 50px;
+    }
 }
 
 .cp-contact-policy {
-    position: absolute;
-    bottom: 32px;
-    left: 32px;
-    right: calc(32px + 202px + 16px);
-    height: 48px;
     display: flex;
-    align-items: center;
+    align-items: flex-end;
+    height: 0;
+
+    aside {
+        width: calc(100% - 202px - 16px);
+    }
 
     @media (max-width: $media-max-width-mobile) {
-        position: static;
         height: auto;
         margin-top: 12px;
+
+        aside {
+            width: 100%;
+        }
     }
 }
 

--- a/website/src/styles/styles.scss
+++ b/website/src/styles/styles.scss
@@ -606,6 +606,12 @@ body .hs-form fieldset.form-columns-1 .hs-input {
 }
 
 .hs-form {
+    &::after {
+        content: "";
+        display: block;
+        clear: both;
+    }
+
     .hs-error-msgs,
     .hs_error_rollup {
         display: none;


### PR DESCRIPTION
## What is the goal of this PR?

Previously when submitting an inline contact form, the success message was displayed over the privacy policy note.
Now the policy note is displayed correctly below the success message.

## What are the changes implemented in this PR?

- changed `p` tag to `aside` to match style of privacy policy note from other forms,
- changed styles of contact policy in contact panel,
- added custom margin to success message in contact panel.
