### PR TITLE
Style tables in technical articles

### DIFF
--- a/common/src/styles/_mixins.scss
+++ b/common/src/styles/_mixins.scss
@@ -105,3 +105,53 @@
 @mixin card-padding {
     padding: var(--card-padding);
 }
+
+@mixin content-table {
+    background: var(--table-body-background);
+    border-radius: var(--border-radius);
+    box-shadow: 0 0 0 1px var(--table-border-color);
+    overflow: hidden;
+
+    > * > tr {
+        border-bottom: 1px solid var(--table-border-color);
+
+        > * {
+            padding: 0.75rem 1.25rem;
+            color: var(--color-white);
+            font-size: 1rem;
+            line-height: 1.75;
+        }
+
+        > th {
+            font-weight: var(--font-weight-semi-bold);
+        }
+
+        > td {
+            font-weight: normal;
+        }
+    }
+
+    > thead > tr > * {
+        background: var(--table-header-background);
+
+        &:first-child {
+            border-top-left-radius: var(--border-radius);
+        }
+
+        &:last-child {
+            border-top-left-radius: var(--border-radius);
+        }
+    }
+
+    > colgroup col:not(:first-of-type) {
+        border-left: 1px solid var(--table-border-color);
+    }
+
+    > tbody > tr:last-child {
+        border-bottom-width: 0;
+    }
+
+    > tfoot {
+        background: var(--table-footer-background);
+    }
+}

--- a/common/src/styles/vars.scss
+++ b/common/src/styles/vars.scss
@@ -26,6 +26,11 @@
     --default-heading-color: var(--color-white);
     --default-text-color: var(--color-dark-white);
 
+    --table-border-color: var(--color-light-purple);
+    --table-header-background: var(--color-deep-purple);
+    --table-body-background: var(--color-purple);
+    --table-footer-background: var(--color-purple);
+
     /* sizes */
     --border-radius: #{$border-radius};
 

--- a/website/src/framework/text/rich-text.component.scss
+++ b/website/src/framework/text/rich-text.component.scss
@@ -1,3 +1,4 @@
+@import "mixins";
 @import "sizes";
 
 :host {
@@ -98,5 +99,9 @@
         &:hover {
             text-decoration: underline;
         }
+    }
+
+    table {
+        @include content-table;
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

Previously tables in technical articles had no padding and used base table layout.
Now it's updated to match docs style.

## What are the changes implemented in this PR?

- created mixin for content table,
- added variables used by content table mixin,
- used new mixin for table in rich text component.
