### PR TITLE
Make common packages used in build installed with common package 

### DIFF
--- a/common/bin/init.js
+++ b/common/bin/init.js
@@ -1,8 +1,4 @@
 const { execSync } = require("child_process");
 const path = require("path");
 
-try {
-    execSync("pnpm build", { cwd: path.dirname(__dirname) });
-} catch (err) {
-    console.log(err);
-}
+execSync("pnpm build", { cwd: path.dirname(__dirname) });

--- a/common/package.json
+++ b/common/package.json
@@ -13,7 +13,7 @@
         "@fontsource/titillium-web": "5.x",
         "prismjs": "1.29.x"
     },
-    "devDependencies": {
+    "dependencies": {
         "@types/prismjs": "1.26.2",
         "typescript": "5.1.6"
     }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -4482,6 +4482,10 @@ packages:
     resolution: {integrity: sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==}
     dev: true
 
+  /@types/prismjs@1.26.2:
+    resolution: {integrity: sha512-/r7Cp7iUIk7gts26mHXD66geUC+2Fo26TZYjQK6Nr4LDfi6lmdRmMqM0oPwfiMhUwoBAOFe8GstKi2pf6hZvwA==}
+    dev: false
+
   /@types/prop-types@15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
     dev: true
@@ -11224,7 +11228,9 @@ packages:
       prismjs: 1.29.x
     dependencies:
       '@fontsource/titillium-web': 5.0.17
+      '@types/prismjs': 1.26.2
       prismjs: 1.29.0
+      typescript: 5.1.6
     dev: false
 
   file:../schema:


### PR DESCRIPTION
## What is the goal of this PR?

Previously typescript and prismjs types had to be installed in parent package.json to make common submodule work.
Now it is installed as dependency even if parent package.json doesn't install it. It's useful for docs as we don't use typescript in docs.

## What are the changes implemented in this PR?

- moved devDependencies to dependencies,
- removed try/catch used for debugging.
