### PR TITLE
Make 404 page return 404 status

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -124,9 +124,15 @@ to = "https://typedb.com/white-papers"
 status = 302
 
 [[redirects]]
+from = "https://typedb.com/404"
+to = "https://typedb.com/__404"
+status = 404
+force = true
+
+[[redirects]]
 from = "https://typedb.com/*"
-to = "https://typedb.com/__fallback.html"
-status = 200
+to = "https://typedb.com/__404"
+status = 404
 
 [[redirects]]
 from = "/*"

--- a/website/scully.typedb-web.config.ts
+++ b/website/scully.typedb-web.config.ts
@@ -1,6 +1,30 @@
-import { ScullyConfig } from "@scullyio/scully";
+import { getSitemapPlugin, SitemapConfig } from "@gammastream/scully-plugin-sitemap";
+import { ScullyConfig, setPluginConfig } from "@scullyio/scully";
 import "@scullyio/scully-plugin-puppeteer";
-import { applicationArticleRoutes, blogCategoryRoutes, blogPostRoutes, eventRoutes, fundamentalArticleRoutes, lectureRoutes, whitePaperRoutes } from "./scully/plugins/plugins";
+
+import {
+    applicationArticleRoutes,
+    blogCategoryRoutes,
+    blogPostRoutes,
+    eventRoutes,
+    fundamentalArticleRoutes,
+    lectureRoutes,
+    whitePaperRoutes,
+} from "./scully/plugins/plugins";
+
+const SitemapPlugin = getSitemapPlugin();
+setPluginConfig<SitemapConfig>(SitemapPlugin, {
+    urlPrefix: process.env["URL"] || "https://typedb.com",
+    changeFreq: "daily",
+    sitemapFilename: "sitemap-main.xml",
+    ignoredRoutes: ["/__404"],
+    routes: {
+        "/": { priority: "0.9" },
+        "/philosophy": { priority: "0.8" },
+        "/features": { priority: "0.7" },
+        "/cloud": { priority: "0.6" },
+    },
+});
 
 export const config: ScullyConfig = {
     projectRoot: "./src",
@@ -16,6 +40,7 @@ export const config: ScullyConfig = {
         "/white-papers/:slug": { type: whitePaperRoutes },
         "/events/:slug": { type: eventRoutes },
     },
+    extraRoutes: ["/__404"],
     puppeteerLaunchOptions: {
         // executablePath: "/opt/homebrew/bin/chromium",
         args: ["--no-sandbox", "--disabled-setupid-sandbox"],

--- a/website/scully/plugins/plugins.ts
+++ b/website/scully/plugins/plugins.ts
@@ -1,5 +1,4 @@
-import { getSitemapPlugin, SitemapConfig } from "@gammastream/scully-plugin-sitemap";
-import { HandledRoute, registerPlugin, setPluginConfig } from "@scullyio/scully";
+import { HandledRoute, registerPlugin } from "@scullyio/scully";
 import axios from "axios";
 
 const defaultValidator = async () => [];
@@ -71,17 +70,3 @@ registerPlugin("router", blogPostRoutes, blogPostRoutesPlugin, defaultValidator)
 registerPlugin("router", lectureRoutes, lectureRoutesPlugin, defaultValidator);
 registerPlugin("router", whitePaperRoutes, whitePaperRoutesPlugin, defaultValidator);
 registerPlugin("router", eventRoutes, eventRoutesPlugin, defaultValidator);
-
-const SitemapPlugin = getSitemapPlugin();
-setPluginConfig<SitemapConfig>(SitemapPlugin, {
-    urlPrefix: process.env.URL || "https://typedb.com",
-    changeFreq: "daily",
-    sitemapFilename: "sitemap-main.xml",
-    ignoredRoutes: ["/404"],
-    routes: {
-        "/": { priority: "0.9" },
-        "/philosophy": { priority: "0.8" },
-        "/features": { priority: "0.7" },
-        "/cloud": { priority: "0.6" },
-    },
-});


### PR DESCRIPTION
## What is the goal of this PR?

Previously `/404` page was returning status 200, and other missing pages were returning `404` status due to bad rewrite target.
Now it is redirected to `/__404` page which should remain hidden from user and is used only as rewrite.

## What are the changes implemented in this PR?

- added rewrite `/404` to `/__404` with 404 status,
- added rewrite all unhandled routes with `/__404` with 404 status,
- moved sitemap plugin to scully config file,
- added `/__404` to extra routes to be rendered by scully.