### PR TITLE
Adding light italic fonts from Google Fonts API

### DIFF
--- a/common/src/styles/fonts.scss
+++ b/common/src/styles/fonts.scss
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Titillium+Web:ital,wght@0,200;0,300;0,400;0,600;0,700;1,400&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Titillium+Web:ital,wght@0,200;0,300;0,400;0,600;0,700;1,200;1,300;1,400&display=swap");
 
 /* Monaco */
 @font-face {


### PR DESCRIPTION
## Release notes: usage and product changes

Our website has many non-bold italics, but in order for these to be rendered correctly we were missing the correct font styles.

## Implementation

Change the Google Fonts API call to include non-bold italics.