### PR TITLE
Make TypeQL syntax highlighting less wrong

### DIFF
--- a/common/src/scripts/prism/prism-typeql.ts
+++ b/common/src/scripts/prism/prism-typeql.ts
@@ -42,9 +42,9 @@ Prism.languages["typeql"] = {
         pattern: /((?<!-)\b| -)[0-9]+(\.[0-9][0-9]*)?\b/,
         alias: "number",
     },
-    boolean: {
+    constant: {
         pattern: /((?<!-)\b)(true|false)((?!-)\b)/,
-        alias: "boolean",
+        alias: "constant",
     },
     operator: {
         pattern: /=|;|\.|\+|\*|\/|\^|,|\(|\)|:|{|}|\[|]|!=|>|<|>=|<=/,

--- a/common/src/styles/prism.scss
+++ b/common/src/styles/prism.scss
@@ -47,7 +47,7 @@ pre[class*="language-"] {
 }
 
 .token.annotation,
-.token.boolean {
+.token.constant {
     color: $prism-orange;
 }
 


### PR DESCRIPTION
## Release notes: usage and product changes

Improved TypeQL highlighting.

## Implementation

* The regex for `number` was fixed (removed erroneous `-`) and now correctly detects word boundaries (pre and post the number). **Note: `-` is discounted from a word boundary** (using a negative lookbehind) since we can have type labels like `my_type_2`
* The regex for `constant` was fixed and now correctly detects word boundaries. Also it now renders as **orange** and not **yellow** (like strings)
* Syntax highlighted for `-` (minus) operator was added, requiring spaces to be rendered correctly.
