### PR TITLE
constant color

### DIFF
--- a/common/src/styles/prism.scss
+++ b/common/src/styles/prism.scss
@@ -35,7 +35,8 @@ pre[class*="language-"] {
     color: $prism-light-green;
 }
 
-.token.string {
+.token.string,
+.token.constant {
     color: $prism-yellow;
 }
 
@@ -54,8 +55,7 @@ pre[class*="language-"] {
     color: $prism-grey;
 }
 
-.token.annotation,
-.token.constant {
+.token.annotation {
     color: $prism-orange;
 }
 


### PR DESCRIPTION
## Release notes: usage and product changes

Switched color of constants (true/false) to that of strings, to avoid conflict with color for annotations.

## Implementation

Edited prism SCSS.


