### PR TITLE
Keyword `first`

### DIFF
--- a/common/src/scripts/prism/prism-typeql.ts
+++ b/common/src/scripts/prism/prism-typeql.ts
@@ -11,7 +11,7 @@ Prism.languages["typeql"] = {
         pattern: /(".*?")|('.*?')/,
     },
     keyword: {
-        pattern: /((?:(?![-a-zA-Z_0-9]|\$|\?).)|^|\s)(define|undefine|match|with|fun|struct|return|reduce|get|filter|assert|insert|delete|put|std|median|mean|max|min|sum|count|group|where|limit|offset|sort|asc|desc|when|then|fetch|rule|like|floor|ceil|round|abs)(?![-a-zA-Z_0-9])/,
+        pattern: /((?:(?![-a-zA-Z_0-9]|\$|\?).)|^|\s)(define|undefine|match|with|fun|struct|return|reduce|get|filter|assert|insert|delete|put|std|median|mean|max|min|first|sum|count|group|where|limit|offset|sort|asc|desc|when|then|fetch|rule|like|floor|ceil|round|abs)(?![-a-zA-Z_0-9])/,
         lookbehind: true,
     },
     constraint: {


### PR DESCRIPTION
## Release notes: usage and product changes

Adding missing keyword `first`.

## Implementation

Added in prism-typeql config.