### PR TITLE
Change constant color

### DIFF
--- a/common/src/styles/prism.scss
+++ b/common/src/styles/prism.scss
@@ -36,8 +36,7 @@ pre[class*="language-"] {
     color: $prism-light-green;
 }
 
-.token.string,
-.token.constant {
+.token.string {
     color: $prism-yellow;
 }
 


### PR DESCRIPTION
## Release notes: usage and product changes

Highlight constant color to look like number values (rather than strings).

## Implementation

Edited prism config.
