### PR TITLE
Host a CSS file referencing our fonts in a static location

### DIFF
--- a/website/src/assets/fonts/email.css
+++ b/website/src/assets/fonts/email.css
@@ -3,8 +3,8 @@
     font-style: normal;
     font-weight: 400;
     src:
-            url(./Monaco.woff2) format("woff2"),
-            url(./Monaco.ttf) format("truetype");
+            url(/assets/fonts/Monaco.woff2) format("woff2"),
+            url(/assets/fonts/Monaco.ttf) format("truetype");
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC,
     U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
     font-display: swap;
@@ -14,7 +14,7 @@
     font-family: "Darkmode";
     font-style: normal;
     font-weight: 200;
-    src: url(./DarkmodeOn_Trial_Th.ttf) format("truetype");
+    src: url(/assets/fonts/DarkmodeOn_Trial_Th.ttf) format("truetype");
     font-display: swap;
 }
 
@@ -22,7 +22,7 @@
     font-family: "Darkmode";
     font-style: italic;
     font-weight: 200;
-    src: url(./DarkmodeOn_Trial_ThIt.ttf) format("truetype");
+    src: url(/assets/fonts/DarkmodeOn_Trial_ThIt.ttf) format("truetype");
     font-display: swap;
 }
 
@@ -30,7 +30,7 @@
     font-family: "Darkmode";
     font-style: normal;
     font-weight: 300;
-    src: url(./DarkmodeOn_Trial_Lt.ttf) format("truetype");
+    src: url(/assets/fonts/DarkmodeOn_Trial_Lt.ttf) format("truetype");
     font-display: swap;
 }
 
@@ -38,7 +38,7 @@
     font-family: "Darkmode";
     font-style: normal;
     font-weight: 400;
-    src: url(./DarkmodeOn_Trial_Rg.ttf) format("truetype");
+    src: url(/assets/fonts/DarkmodeOn_Trial_Rg.ttf) format("truetype");
     font-display: swap;
 }
 
@@ -46,7 +46,7 @@
     font-family: "Darkmode";
     font-style: italic;
     font-weight: 400;
-    src: url(./DarkmodeOn_Trial_It.ttf) format("truetype");
+    src: url(/assets/fonts/DarkmodeOn_Trial_It.ttf) format("truetype");
     font-display: swap;
 }
 
@@ -54,7 +54,7 @@
     font-family: "Darkmode";
     font-style: normal;
     font-weight: 500;
-    src: url(./DarkmodeOn_Trial_Md.ttf) format("truetype");
+    src: url(/assets/fonts/DarkmodeOn_Trial_Md.ttf) format("truetype");
     font-display: swap;
 }
 
@@ -62,7 +62,7 @@
     font-family: "Darkmode";
     font-style: normal;
     font-weight: 600;
-    src: url(./DarkmodeOn_Trial_SBd.ttf) format("truetype");
+    src: url(/assets/fonts/DarkmodeOn_Trial_SBd.ttf) format("truetype");
     font-display: swap;
 }
 
@@ -70,7 +70,7 @@
     font-family: "Darkmode";
     font-style: normal;
     font-weight: 700;
-    src: url(./DarkmodeOn_Trial_Bd.ttf) format("truetype");
+    src: url(/assets/fonts/DarkmodeOn_Trial_Bd.ttf) format("truetype");
     font-display: swap;
 }
 


### PR DESCRIPTION
## Release notes: usage and product changes

We add a CSS file hosted at `/assets/fonts/email.css` that defines our fonts. This is used by Customer IO to use our fonts in our emails.

## Implementation

We add the required CSS file at `/assets/fonts` so it's in a static location where customer IO can access it.