### PR TITLE
Add stylings from TypeDB Cloud work

### DIFF
--- a/common/src/styles/base.scss
+++ b/common/src/styles/base.scss
@@ -377,11 +377,11 @@ td-form .form-row {
     --important-color: #{colors.$secondary-yellow};
     --important-background: #{rgba(colors.$secondary-yellow, 0.09)};
     --note-color: #{colors.$secondary-blue};
-    --note-background: #{rgba(colors.$secondary-blue, 0.12)};
+    --note-background: #{rgba(colors.$secondary-blue, 0.09)};
     --tip-color: #{colors.$green};
-    --tip-background: #{rgba(colors.$green, 0.12)};
+    --tip-background: #{rgba(colors.$green, 0.09)};
     --warning-color: #{colors.$red};
-    --warning-background: #{rgba(colors.$red, 0.12)};
+    --warning-background: #{rgba(colors.$red, 0.09)};
 
     position: relative;
     margin: 0.5rem 0 1.5rem;

--- a/common/src/styles/base.scss
+++ b/common/src/styles/base.scss
@@ -375,7 +375,7 @@ td-form .form-row {
 
 .admonitionblock {
     --important-color: #{colors.$secondary-yellow};
-    --important-background: #{rgba(colors.$secondary-yellow, 0.12)};
+    --important-background: #{rgba(colors.$secondary-yellow, 0.09)};
     --note-color: #{colors.$secondary-blue};
     --note-background: #{rgba(colors.$secondary-blue, 0.12)};
     --tip-color: #{colors.$green};

--- a/common/src/styles/material.scss
+++ b/common/src/styles/material.scss
@@ -228,6 +228,7 @@ body {
 
     .mat-mdc-chip-focus-overlay {
         opacity: 0 !important; /* overrides Angular Material styles */
+        backdrop-filter: blur(10px);
     }
 
     .mdc-evolution-chip-set .mdc-evolution-chip-set__chips {
@@ -807,4 +808,10 @@ body {
     mat-tree-node[mattreenodetoggle] {
         cursor: pointer;
     }
+
+
+    /* Autocomplete */
+    @include mat.autocomplete-overrides((
+        background-color: colors.$purple,
+    ));
 }


### PR DESCRIPTION
## Release notes: usage and product changes

We add some stylings developed for TypeDB Cloud, namely:
- blurring the background when dialogs open
- Reducing the opacity of `admonitionblock`
- Adding appropriate background colors for `mat-autocomplete` elements

## Implementation

Add required stylings
