### PR TITLE
Blog SEO improvements

### DIFF
--- a/main/src/framework/hot-topics/hot-topics.component.scss
+++ b/main/src/framework/hot-topics/hot-topics.component.scss
@@ -105,6 +105,10 @@ td-hot-topics {
         display: flex;
         flex-direction: column;
         gap: 16px;
+
+        h3 {
+            @include mixins.line-clamp(2);
+        }
     }
 
     td-actions {

--- a/main/src/page/blog/blog-row.component.html
+++ b/main/src/page/blog/blog-row.component.html
@@ -4,7 +4,7 @@
       <div class="bp-posts-row bp-primary-post">
         <a class="bp-primary-img-link" [tdLink]="posts.posts[0].readPostLink()">
           <td-aspect-ratio ratio="16:9">
-            <img [ngSrc]="posts.posts[0].imageURL!" alt="" fill class="bp-img" />
+            <img [ngSrc]="posts.posts[0].imageURL!" [alt]="posts.posts[0].title | plainText" fill class="bp-img" />
           </td-aspect-ratio>
         </a>
         <div class="bp-primary-post-summary">
@@ -12,7 +12,6 @@
           <a [tdLink]="posts.posts[0].readPostLink()">
             <h2 class="bp-post-title bp-primary-post-title">{{ posts.posts[0].title | plainText }}</h2>
           </a>
-          <!-- <td-rich-text class="bp-primary-post-description" [value]="posts.posts[0].description" /> -->
           <td-blog-authorship-bar [post]="posts.posts[0]" />
         </div>
       </div>
@@ -24,7 +23,7 @@
             <div class="bp-secondary-post">
               <a [tdLink]="post.readPostLink()">
                 <td-aspect-ratio ratio="16:9">
-                  <img [ngSrc]="post.heroImageURL()" alt="" fill class="bp-img" />
+                  <img [ngSrc]="post.heroImageURL()" [alt]="post.title | plainText" fill class="bp-img" />
                 </td-aspect-ratio>
               </a>
               <div class="bp-secondary-post-summary">
@@ -32,31 +31,11 @@
                 <a [tdLink]="post.readPostLink()">
                   <h2 class="bp-post-title text-h5">{{ post.title | plainText }}</h2>
                 </a>
-                <!-- <td-rich-text class="bp-secondary-post-description" [value]="post.description" /> -->
                 <td-blog-authorship-bar [post]="post" />
               </div>
             </div>
           }
         }
-      </div>
-    }
-    @case ('tertiary') {
-      <div class="bp-posts-row bp-tertiary-post">
-        <div class="bp-img-tertiary-container">
-          <a class="bp-tertiary-img-link" [tdLink]="posts.posts[0].readPostLink()">
-            <td-aspect-ratio ratio="16:9" class="bp-img-tertiary">
-              <img [ngSrc]="posts.posts[0].imageURL!" class="bp-img" alt="" fill />
-            </td-aspect-ratio>
-          </a>
-        </div>
-        <div class="bp-post-text-tertiary">
-          <td-blog-category-chips [post]="posts.posts[0]" />
-          <a [tdLink]="posts.posts[0].readPostLink()">
-            <h2 class="bp-post-title text-h3">{{ posts.posts[0].title | plainText }}</h2>
-          </a>
-          <!-- <td-rich-text class="bp-tertiary-post-description" [value]="posts.posts[0].description" /> -->
-          <td-blog-authorship-bar [post]="posts.posts[0]" />
-        </div>
       </div>
     }
   }

--- a/main/src/page/blog/blog-row.component.scss
+++ b/main/src/page/blog/blog-row.component.scss
@@ -179,44 +179,6 @@ td-blog-row {
         list-style: none;
     }
 
-    .bp-tertiary-post {
-        @media (min-width: media.$min-width-tablet) {
-            display: flex;
-            flex-direction: row;
-            align-items: center;
-            gap: 40px;
-        }
-    }
-
-    .bp-img-tertiary-container {
-        flex: 11;
-        display: flex;
-        gap: 12px;
-    }
-
-    .bp-tertiary-img-link,
-    .bp-img-tertiary {
-        width: 100%;
-        flex-shrink: 0;
-    }
-
-    .bp-post-text-tertiary {
-        flex: 21;
-        display: flex;
-        flex-direction: column;
-        margin-top: 2px;
-
-        .bp-post-title {
-            @include mixins.line-clamp(1);
-        }
-
-        .bp-tertiary-post-description {
-            font-weight: var(--font-weight-light);
-            margin-top: 12px;
-            @include mixins.line-clamp(3);
-        }
-    }
-
     td-heading-with-highlights + td-resource-panels {
         display: block;
         margin-top: 24px;

--- a/main/src/page/blog/blog-row.component.ts
+++ b/main/src/page/blog/blog-row.component.ts
@@ -8,7 +8,6 @@ import { AspectRatioComponent } from "../../framework/aspect-ratio/aspect-ratio.
 import { ResourcePanelsComponent } from "../../framework/link-panels/link-panels.component";
 import { LinkDirective } from "../../framework/link/link.directive";
 import { PlainTextPipe } from "../../framework/text/plain-text.pipe";
-import { RichTextComponent } from "../../framework/text/rich-text.component";
 import { HeadingWithHighlightsComponent } from "../../framework/text/text-with-highlights.component";
 import { BlogAuthorshipBarComponent } from "./blog-authorship-bar.component";
 import { BlogCategoryChipsComponent } from "./blog-category-chips.component";
@@ -16,11 +15,10 @@ import { BlogCategoryChipsComponent } from "./blog-category-chips.component";
 @Component({
     selector: "td-blog-row",
     templateUrl: "./blog-row.component.html",
-    
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     imports: [
-        LinkDirective, AspectRatioComponent, BlogCategoryChipsComponent, RichTextComponent,
+        LinkDirective, AspectRatioComponent, BlogCategoryChipsComponent,
         BlogAuthorshipBarComponent, HeadingWithHighlightsComponent, ResourcePanelsComponent, PlainTextPipe,
         NgOptimizedImage
     ]

--- a/main/src/page/blog/blog.component.html
+++ b/main/src/page/blog/blog.component.html
@@ -1,9 +1,9 @@
 <article>
   @if (blog$ | async; as blog) {
-    <!-- <section class="blog-landing-strip">
+    <section class="blog-landing-strip">
       <a tdLink="/blog"><td-heading-with-highlights [value]="blog.blogTitle" level="h1" renderedLevel="h2" /></a>
-      <td-p-with-highlights class="narrow-section subtitle-l text-p1" [value]="blog.blogSubtitle" />
-    </section> -->
+      <!-- <td-p-with-highlights class="narrow-section subtitle-l text-p1" [value]="blog.blogSubtitle" /> -->
+    </section>
   }
 
   <div class="section-background-solid bp-blog-list">

--- a/main/src/page/home/home-page.component.html
+++ b/main/src/page/home/home-page.component.html
@@ -3,8 +3,8 @@
     @if (page.introSection) {
       <td-section-core level="h1" [section]="page.introSection" class="td-intro" flexDirection="column" />
     }
-    @if (page.hotTopicsSection) {
-      <td-hot-topics [title]="page.hotTopicsSection.title" [resources]="page.hotTopicsSection.hotTopics" [actions]="page.hotTopicsSection.actions"/>
+    @if (page.hotTopicsSection; as hotTopics) {
+      <td-hot-topics [title]="hotTopics.title" [resources]="(latestPosts$ | async) || []" [actions]="hotTopics.actions"/>
     }
     @if (page.benefitsSection1) {
       <td-section-core [section]="page.benefitsSection1" flexDirection="row"/>

--- a/main/src/page/resource-hub/learning-article.component.ts
+++ b/main/src/page/resource-hub/learning-article.component.ts
@@ -117,6 +117,7 @@ export class LearningArticleComponent implements OnInit {
             title: article.pageTitle(),
             description: description || article.shortDescription,
             ogImage: article.imageURL,
+            ogType: "article" as const,
         };
     }
 

--- a/main/src/root.component.ts
+++ b/main/src/root.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectorRef, Component, HostBinding, inject, PLATFORM_ID } from "@angular/core";
 import { MatIconRegistry } from "@angular/material/icon";
 import { DomSanitizer } from "@angular/platform-browser";
-import { ActivatedRoute, NavigationEnd, Router, Event as RouterEvent, RouterOutlet, Scroll, NavigationStart } from "@angular/router";
+import { ActivatedRoute, NavigationEnd, Router, Event as RouterEvent, RouterOutlet, Scroll } from "@angular/router";
 import { TopbarMenuComponent } from "./navigation/topbar/topbar-menu.component";
 import { FooterComponent } from "./navigation/footer/footer.component";
 import { FeedbackButtonComponent } from "./navigation/feedback/feedback-button.component";
@@ -9,11 +9,8 @@ import { ContentService } from "./service/content.service";
 import { SanitySiteBanner, siteBannerSchemaName } from "typedb-web-schema";
 import { AnalyticsService } from "./service/analytics.service";
 import { filter } from "rxjs";
-import { CanonicalLinkService } from "./service/canonical-link.service";
 import { LocationStrategy, ViewportScroller, Location, DOCUMENT, isPlatformBrowser } from "@angular/common";
 import { environment } from "./environment/environment";
-
-const SITE_URL = "https://typedb.com";
 
 @Component({
     selector: "td-web-main",
@@ -32,7 +29,6 @@ export class RootComponent {
     private readonly analyticsService = inject(AnalyticsService);
     private readonly router = inject(Router);
     private readonly activatedRoute = inject(ActivatedRoute);
-    private readonly canonicalLink = inject(CanonicalLinkService);
     private readonly viewportScroller = inject(ViewportScroller);
     private readonly locationStrategy = inject(LocationStrategy);
     private readonly location = inject(Location);
@@ -43,7 +39,6 @@ export class RootComponent {
     private _pathnameBeforeNavigation = this.locationPathname();
 
     constructor() {
-        this.setCanonicalLinkOnNavigation();
         this.registerIcons();
 
         if (isPlatformBrowser(this.platformId)) {
@@ -70,17 +65,6 @@ export class RootComponent {
         this.router.events.pipe(filter((event: RouterEvent) => event instanceof NavigationEnd)).subscribe(() => {
             this.analyticsService.posthog.capturePageView();
             this.analyticsService.cio.page();
-        });
-    }
-
-    private setCanonicalLinkOnNavigation() {
-        this.router.events.subscribe((e) => {
-            if (e instanceof NavigationStart) {
-                this.canonicalLink.removeCanonical();
-            }
-            if (e instanceof NavigationEnd) {
-                this.canonicalLink.setCanonical(`${SITE_URL}${e.url.split(/[#?]/)[0]}`);
-            }
         });
     }
 

--- a/main/src/service/canonical-link.service.ts
+++ b/main/src/service/canonical-link.service.ts
@@ -1,30 +1,51 @@
 import { Inject, Injectable, DOCUMENT } from "@angular/core";
-import { BehaviorSubject, distinct, filter, map, skip } from "rxjs";
+import { Meta } from "@angular/platform-browser";
+import { NavigationEnd, Router } from "@angular/router";
+import { BehaviorSubject, distinctUntilChanged, filter, map } from "rxjs";
+
+const SITE_URL = "https://typedb.com";
 
 @Injectable({
     providedIn: "root",
 })
 export class CanonicalLinkService {
     private href$ = new BehaviorSubject<string | null>(null);
+    private override$ = new BehaviorSubject<string | null>(null);
 
-    constructor(@Inject(DOCUMENT) doc: Document) {
+    constructor(@Inject(DOCUMENT) doc: Document, private meta: Meta, router: Router) {
         const linkEl = doc.createElement("link");
         linkEl.rel = "canonical";
+        doc.head.appendChild(linkEl);
 
-        this.href$.pipe(filter((v): v is string => !!v)).subscribe((href) => {
-            linkEl.href = href;
+        // Set default canonical on navigation
+        router.events.pipe(
+            filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+            map((e) => `${SITE_URL}${e.url.split(/[#?]/)[0]}`),
+        ).subscribe((url) => {
+            this.href$.next(url);
+            this.override$.next(null);
         });
 
-        this.href$.pipe(map((v) => !!v), distinct(), skip(1)).subscribe((v) =>
-            (v ? doc.head.appendChild(linkEl) : doc.head.removeChild(linkEl))
-        );
+        // Effective canonical = override if set, otherwise default
+        this.href$.pipe(
+            map(() => this.override$.value || this.href$.value),
+            filter((v): v is string => !!v),
+            distinctUntilChanged(),
+        ).subscribe((href) => {
+            linkEl.href = href;
+            this.meta.updateTag({ property: "og:url", content: href });
+        });
+
+        this.override$.pipe(
+            filter((v): v is string => !!v),
+        ).subscribe((href) => {
+            linkEl.href = href;
+            this.meta.updateTag({ property: "og:url", content: href });
+        });
     }
 
-    removeCanonical(): void {
-        this.href$.next(null);
-    }
-
-    setCanonical(val: string) {
-        this.href$.next(val);
+    /** Override the default canonical URL for this page */
+    setCanonical(val: string): void {
+        this.override$.next(val);
     }
 }

--- a/main/src/service/json-ld.service.ts
+++ b/main/src/service/json-ld.service.ts
@@ -1,0 +1,116 @@
+import { DOCUMENT } from "@angular/common";
+import { Inject, Injectable } from "@angular/core";
+
+import { BlogPost } from "typedb-web-schema";
+
+export interface BlogPostingSchema {
+    "@context": "https://schema.org";
+    "@type": "BlogPosting";
+    headline: string;
+    description?: string;
+    image?: string;
+    datePublished: string;
+    dateModified?: string;
+    author: {
+        "@type": "Person";
+        name: string;
+        url?: string;
+    };
+    publisher: {
+        "@type": "Organization";
+        name: string;
+        logo?: {
+            "@type": "ImageObject";
+            url: string;
+        };
+    };
+    mainEntityOfPage: {
+        "@type": "WebPage";
+        "@id": string;
+    };
+}
+
+export interface BlogSchema {
+    "@context": "https://schema.org";
+    "@type": "Blog";
+    name: string;
+    description?: string;
+    url: string;
+    publisher: {
+        "@type": "Organization";
+        name: string;
+        logo?: {
+            "@type": "ImageObject";
+            url: string;
+        };
+    };
+}
+
+@Injectable({
+    providedIn: "root",
+})
+export class JsonLdService {
+    private scriptElement: HTMLScriptElement | null = null;
+
+    private readonly PUBLISHER = {
+        "@type": "Organization" as const,
+        name: "TypeDB",
+        logo: {
+            "@type": "ImageObject" as const,
+            url: "https://typedb.com/assets/meta/android-chrome-512x512.png",
+        },
+    };
+
+    constructor(@Inject(DOCUMENT) private doc: Document) {}
+
+    setForBlogPost(post: BlogPost, pageUrl: string): void {
+        const schema: BlogPostingSchema = {
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            headline: post.title.toPlainText(),
+            description: post.shortDescription,
+            image: post.heroImageURL(),
+            datePublished: post.date.toISOString(),
+            author: {
+                "@type": "Person",
+                name: post.author.name,
+            },
+            publisher: this.PUBLISHER,
+            mainEntityOfPage: {
+                "@type": "WebPage",
+                "@id": pageUrl,
+            },
+        };
+
+        this.setJsonLd(schema);
+    }
+
+    setForBlogListing(name: string, description: string | undefined, pageUrl: string): void {
+        const schema: BlogSchema = {
+            "@context": "https://schema.org",
+            "@type": "Blog",
+            name,
+            description,
+            url: pageUrl,
+            publisher: this.PUBLISHER,
+        };
+
+        this.setJsonLd(schema);
+    }
+
+    remove(): void {
+        if (this.scriptElement && this.scriptElement.parentNode) {
+            this.scriptElement.parentNode.removeChild(this.scriptElement);
+            this.scriptElement = null;
+        }
+    }
+
+    private setJsonLd(schema: BlogPostingSchema | BlogSchema): void {
+        this.remove();
+
+        this.scriptElement = this.doc.createElement("script");
+        this.scriptElement.type = "application/ld+json";
+        this.scriptElement.text = JSON.stringify(schema);
+        this.doc.head.appendChild(this.scriptElement);
+    }
+}

--- a/main/src/service/meta-tags.service.ts
+++ b/main/src/service/meta-tags.service.ts
@@ -3,10 +3,22 @@ import { Meta, MetaDefinition } from "@angular/platform-browser";
 
 import { MetaTags } from "typedb-web-schema";
 
+export type OgType = "website" | "article";
+
+export interface ArticleMeta {
+    publishedTime: Date;
+    modifiedTime?: Date;
+    author?: string;
+    section?: string;
+    tags?: string[];
+}
+
 export interface MetaTagFallbacks {
     title?: string;
     description?: string;
     ogImage?: string;
+    ogType?: OgType;
+    article?: ArticleMeta;
 }
 
 @Injectable({
@@ -30,10 +42,30 @@ export class MetaTagsService {
         metaDefinitions.push({ name: "twitter:title", content: title });
 
         metaDefinitions.push({ name: "description", content: description });
+        metaDefinitions.push({ property: "og:description", content: description });
         metaDefinitions.push({ name: "twitter:description", content: description });
 
         metaDefinitions.push({ property: "og:image", content: ogImage });
         metaDefinitions.push({ name: "twitter:image", content: ogImage });
+
+        metaDefinitions.push({ property: "og:type", content: fallbacks?.ogType || "website" });
+
+        if (fallbacks?.article) {
+            const { publishedTime, modifiedTime, author, section, tags } = fallbacks.article;
+            metaDefinitions.push({ property: "article:published_time", content: publishedTime.toISOString() });
+            if (modifiedTime) {
+                metaDefinitions.push({ property: "article:modified_time", content: modifiedTime.toISOString() });
+            }
+            if (author) {
+                metaDefinitions.push({ property: "article:author", content: author });
+            }
+            if (section) {
+                metaDefinitions.push({ property: "article:section", content: section });
+            }
+            if (tags) {
+                tags.forEach(tag => metaDefinitions.push({ property: "article:tag", content: tag }));
+            }
+        }
 
         if (metaTags.keywords?.length) {
             metaDefinitions.push({ name: "keywords", content: metaTags.keywords });

--- a/schema/index.ts
+++ b/schema/index.ts
@@ -81,7 +81,7 @@ export {
 } from "./page/learn";
 export { LecturesPage, type SanityLecturesPage, lecturesPageSchemaName } from "./page/lectures";
 export { LegalDocument, type SanityLegalDocument, legalDocumentSchemaName } from "./page/legal";
-export { HomePage, homePageSchemaName, type SanityHomePage, SocialValidationSection } from "./page/home";
+export { HomePage, homePageSchemaName, type SanityHomePage, SocialValidationSection, LatestPostsSection } from "./page/home";
 export { type SanityPapersPage, PapersPage, papersPageSchemaName } from "./page/papers";
 export { PricingPage, pricingPageSchemaName, type SanityPricingPage } from "./page/pricing";
 export {

--- a/schema/resource/article.ts
+++ b/schema/resource/article.ts
@@ -152,6 +152,10 @@ export class BlogPost extends Article {
     pageTitle(): string {
         return `TypeDB Blog: ${this.title.toPlainText()}`;
     }
+
+    canonicalURL(): string {
+        return this.canonicalUrl || `https://typedb.com/blog/${this.slug}`;
+    }
 }
 
 export function articleFromWPApi(data: SanityArticle, db: SanityDataset, wordpressPost: WordpressPost): Article {


### PR DESCRIPTION
## Release notes: usage and product changes

We've made significant changes that should improve blog SEO

## Implementation

- Implement JSON-LD (schema.org) schema for all blog landing pages and posts
- Add the following meta tags to all blog posts: `og:type`, `og:description`, `article:published_date`, `article:author`, `article:section`, `article:tag`
- Ensure blog landing pages have a visible H1 saying "TypeDB Blog"
- Ensure all blog hero images have alt text
- Make "hot topics" on home page always be the 5 latest blog posts
- (Refactor) Centralise canonical URL and meta og:url configuration logic